### PR TITLE
Add deduper option for one_per_author

### DIFF
--- a/jenkins/build.py
+++ b/jenkins/build.py
@@ -1,0 +1,28 @@
+"""
+A class for working with the build info returned from the jenkins job API
+"""
+
+
+class Build(dict):
+    """
+    A class for working with the build info returned from the jenkins job API
+
+    :Args:
+        build (dict): build data from Jenkins
+    """
+    def __init__(self, build):
+        self.isbuilding = build.get('building')
+
+        author = None
+        pr_id = None
+        actions = build.get('actions')
+        if actions:
+            action_parameters = actions[0].get('parameters')
+            for p in action_parameters:
+                if p.get('name') == u'ghprbActualCommitAuthorEmail':
+                    author = p.get('value')
+                if p.get('name') == u'ghprbPullId':
+                    pr_id = p.get('value')
+
+        self.author = author
+        self.pr_id = pr_id

--- a/jenkins/deduper.py
+++ b/jenkins/deduper.py
@@ -8,11 +8,10 @@ from collections import defaultdict
 from operator import itemgetter
 import argparse
 import logging
-import json
-import re
 import sys
 
 from job import JenkinsJob
+from build import Build
 
 
 logging.basicConfig(format='[%(levelname)s] %(message)s')
@@ -20,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 
 class GhprbOutdatedBuildAborter:
+
     """
     A class for programatically finding and aborting outdated
     jenkins builds that were started using the GHPRB plugin.
@@ -28,8 +28,9 @@ class GhprbOutdatedBuildAborter:
         job: An instance of jenkins_api.job.JenkinsJob
     """
 
-    def __init__(self, job):
+    def __init__(self, job, one_per_author=False):
         self.job = job
+        self.one_per_author = one_per_author
 
     @staticmethod
     def _aborted_description(current_build_id, pr):
@@ -63,29 +64,65 @@ class GhprbOutdatedBuildAborter:
         Return build data for currently running builds.
 
         :Args:
-            data: the return value of self.get_json()
+            data (dict): the return value of self.get_json()
+
+        :Raises:
+            KeyError if there is no 'builds' key in the data
 
         :Returns:
-            build_data: a dict where keys are a PR id and the value is
-                a list of 'builds' for the PR. Each item in the list
-                has the data for the build as returned in self.get_json.
+            dict: where keys are a PR id and the value is
+            a list of 'builds' for the PR. Each item in the list
+            has the data for the build as returned in self.get_json.
         """
         build_data = defaultdict(list)
 
-        # This is used to find the PR id instead of having a bunch of
-        # messy loops.
-        pr_id_regex = (r"{[\s-]*\"name\"[\s-]*:[\s-]*\"ghprbPullId\""
-                       r"[\s-]*,[\s-]*\"value\"[\s-]*:[\s-]*\"[\d]*\"}")
-
         for b in data['builds']:
-            if b['building']:
-                pr_id_data_str = re.search(
-                    pr_id_regex, json.dumps(b['actions'])).group(0)
-                pr_id_data = json.loads(pr_id_data_str)
-                pr_id = pr_id_data['value']
-                build_data[pr_id].append(b)
+            build = Build(b)
+            if build.isbuilding:
+                build_data[build.pr_id].append(b)
 
         return build_data
+
+    def stop_all_but_most_recent(self, pr, builds):
+        """
+        Stop all the builds in the list but the most recently initiated.
+
+        :Args:
+            pr (str): PR number of the build, used for logging purposes
+            builds (list of dict): list of running builds for that PR
+
+        :Returns:
+            list of str: output to add for logging
+        """
+        output = []
+        if len(builds) > 1:
+            # Sort builds by timestamp (newest to oldest)
+            sorted_builds = sorted(
+                builds, key=itemgetter('timestamp'), reverse=True)
+
+            # Most recently started build is the first in the list
+            current_build_id = sorted_builds[0]['number']
+
+            # Any other builds are assumed to be outdated
+            old_build_ids = [b['number'] for b in sorted_builds[1:]]
+
+            output.append("PR #{}:".format(pr))
+            output.append("\tNum running builds: {}".format(
+                len(sorted_builds)))
+            output.append("\tCurrent build: {}".format(
+                current_build_id))
+            output.append("\tOutdated builds: {}".format(
+                old_build_ids))
+
+            desc = self._aborted_description(current_build_id, pr)
+
+            for b in old_build_ids:
+                try:
+                    self.job.stop_build(b)
+                    self.job.update_build_desc(b, desc)
+                except Exception as e:
+                    logger.error(e.message)
+        return output
 
     def stop_duplicates(self, build_data):
         """
@@ -96,35 +133,27 @@ class GhprbOutdatedBuildAborter:
         """
         lines = []
         for pr, builds in build_data.iteritems():
-            if len(builds) > 1:
-                # Sort builds by timestamp (newest to oldest)
-                sorted_builds = sorted(
-                    builds, key=itemgetter('timestamp'), reverse=True)
+            if self.one_per_author:
+                # Assemble a dict where the key is the author and the
+                # value is a list of that author's builds.
+                pr_builds = defaultdict(list)
+                for build in builds:
+                    author = Build(build).author
+                    pr_builds[author].append(build)
 
-                # Most recently started build is the first in the list
-                current_build_id = sorted_builds[0]['number']
+                # Now for each author, stop all but the most
+                # recent build.
+                for build_list in pr_builds.itervalues():
+                    output = self.stop_all_but_most_recent(pr, build_list)
+                    if len(output) > 0:
+                        lines.extend(output)
 
-                # Any other builds are assumed to be outdated
-                old_build_ids = [b['number'] for b in sorted_builds[1:]]
+            else:
+                output = self.stop_all_but_most_recent(pr, builds)
+                if len(output) > 0:
+                    lines.extend(output)
 
-                lines.append("PR #{}:".format(pr))
-                lines.append("\tNum running builds: {}".format(
-                    len(sorted_builds)))
-                lines.append("\tCurrent build: {}".format(
-                    current_build_id))
-                lines.append("\tOutdated builds: {}".format(
-                    old_build_ids))
-
-                desc = self._aborted_description(current_build_id, pr)
-
-                for b in old_build_ids:
-                    try:
-                        self.job.stop_build(b)
-                        self.job.update_build_desc(b, desc)
-                    except Exception as e:
-                        logger.error(e.message)
-
-        if lines:
+        if len(lines) > 0:
             out = ("\n---------------------------------"
                    "\n** Extra running builds found. **"
                    "\n---------------------------------\n")
@@ -136,18 +165,23 @@ class GhprbOutdatedBuildAborter:
 
 def deduper_main(raw_args):
     # Get args
-    parser = argparse.ArgumentParser(
-        description="Programatically abort oldest builds for"
-                    "a PR so that only one is running.")
-    parser.add_argument('--token', '-t', dest='token',
-                        help='jeknins api token', required=True)
-    parser.add_argument('--user', '-u', dest='username',
-                        help='jenkins username', required=True)
-    parser.add_argument('--job', '-j', dest='job_url',
-                        help='URL of jenkins job that uses the GHPRB plugin',
-                        required=True)
-    parser.add_argument('--log-level', dest='log_level',
-                        default="INFO", help="set logging level")
+    desc = "Programatically abort older, still-running builds for a PR."
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument(
+        '--token', '-t', dest='token',
+        help='jenkins api token', required=True)
+    parser.add_argument(
+        '--user', '-u', dest='username',
+        help='jenkins username', required=True)
+    parser.add_argument(
+        '--job', '-j', dest='job_url', required=True,
+        help='URL of jenkins job that uses the GHPRB plugin')
+    parser.add_argument(
+        '--one-per-author', dest='one_per_author', default=False,
+        help="Leave one build for each unique last commit author for a PR.")
+    parser.add_argument(
+        '--log-level', dest='log_level',
+        default="INFO", help="set logging level")
     args = parser.parse_args(raw_args)
 
     # Set logging level
@@ -155,7 +189,7 @@ def deduper_main(raw_args):
 
     # Abort extra jobs
     job = JenkinsJob(args.job_url, args.username, args.token)
-    deduper = GhprbOutdatedBuildAborter(job)
+    deduper = GhprbOutdatedBuildAborter(job, args.one_per_author)
     deduper.abort_duplicate_builds()
 
 

--- a/jenkins/job.py
+++ b/jenkins/job.py
@@ -13,6 +13,7 @@ logging.getLogger('requests').setLevel('ERROR')
 
 
 class JenkinsJob:
+
     """
     A class for interacting with the jenkins job API
 

--- a/jenkins/tests/test_deduper.py
+++ b/jenkins/tests/test_deduper.py
@@ -2,12 +2,13 @@ from mock import patch
 from requests.exceptions import HTTPError
 from unittest import TestCase
 
-from jenkins.tests.helpers import mock_response, sample_data
+from jenkins.tests.helpers import sample_data, Pr
 from jenkins.deduper import GhprbOutdatedBuildAborter, deduper_main
 from jenkins.job import JenkinsJob
 
 
 class DeduperTestCase(TestCase):
+
     """
     TestCase class for testing deduper.py.
     """
@@ -20,17 +21,20 @@ class DeduperTestCase(TestCase):
         self.deduper = GhprbOutdatedBuildAborter(job)
 
     def test_get_running_builds_3_building(self):
-        data = sample_data(['1', '2', '3'], ['4'])
+        data = sample_data(
+            [Pr('1').dict, Pr('2').dict, Pr('3').dict], [Pr('4').dict])
         builds = self.deduper.get_running_builds(data)
         self.assertEqual(len(builds), 3)
 
     def test_get_running_builds_1_building(self):
-        data = sample_data(['4'], ['1', '2', '3'])
+        data = sample_data(
+            [Pr('4').dict], [Pr('1').dict, Pr('2').dict, Pr('3').dict])
         builds = self.deduper.get_running_builds(data)
         self.assertEqual(len(builds), 1)
 
     def test_get_running_builds_none_building(self):
-        data = sample_data([], ['1', '2', '3', '4'])
+        data = sample_data(
+            [], [Pr('1').dict, Pr('2').dict, Pr('3').dict, Pr('4').dict])
         builds = self.deduper.get_running_builds(data)
         self.assertEqual(len(builds), 0)
 
@@ -47,8 +51,9 @@ class DeduperTestCase(TestCase):
     def test_stop_duplicates_with_duplicates(self, mock_desc,
                                              update_desc,
                                              stop_build):
-        sample_buid_data = sample_data(['1', '2', '2', '3'], [])
-        build_data = self.deduper.get_running_builds(sample_buid_data)
+        sample_build_data = sample_data(
+            [Pr('1').dict, Pr('2').dict, Pr('2').dict, Pr('3').dict], [])
+        build_data = self.deduper.get_running_builds(sample_build_data)
         self.deduper.stop_duplicates(build_data)
         stop_build.assert_called_once_with(2)
         update_desc.assert_called_once_with(2, mock_desc())
@@ -56,8 +61,9 @@ class DeduperTestCase(TestCase):
     @patch('jenkins.job.JenkinsJob.stop_build', side_effect=HTTPError())
     @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
     def test_stop_duplicates_failed_to_stop(self, update_desc, stop_build):
-        sample_buid_data = sample_data(['1', '2', '2', '3'], [])
-        build_data = self.deduper.get_running_builds(sample_buid_data)
+        sample_build_data = sample_data(
+            [Pr('1').dict, Pr('2').dict, Pr('2').dict, Pr('3').dict], [])
+        build_data = self.deduper.get_running_builds(sample_build_data)
         self.deduper.stop_duplicates(build_data)
         stop_build.assert_called_once_with(2)
         self.assertFalse(update_desc.called)
@@ -65,14 +71,16 @@ class DeduperTestCase(TestCase):
     @patch('jenkins.job.JenkinsJob.stop_build', return_value=True)
     @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
     def test_stop_duplicates_no_duplicates(self, update_desc, stop_build):
-        sample_buid_data = sample_data(['1', '2', '3'], ['2'])
-        build_data = self.deduper.get_running_builds(sample_buid_data)
+        sample_build_data = sample_data(
+            [Pr('1').dict, Pr('2').dict, Pr('3').dict], [Pr('2').dict])
+        build_data = self.deduper.get_running_builds(sample_build_data)
         self.deduper.stop_duplicates(build_data)
         self.assertFalse(stop_build.called)
         self.assertFalse(update_desc.called)
 
-    @patch('jenkins.job.JenkinsJob.get_json',
-           return_value=sample_data(['1', '2', '2', '3'], ['4', '5', '5']))
+    @patch('jenkins.job.JenkinsJob.get_json', return_value=sample_data(
+        [Pr('1').dict, Pr('2').dict, Pr('2').dict, Pr('3').dict],
+        [Pr('4').dict, Pr('5').dict, Pr('5').dict]))
     @patch('jenkins.job.JenkinsJob.stop_build', return_value=True)
     @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
     @patch('jenkins.deduper.GhprbOutdatedBuildAborter._aborted_description',
@@ -89,3 +97,45 @@ class DeduperTestCase(TestCase):
         get_json.assert_called_once_with()
         stop_build.assert_called_once_with(2)
         update_desc.assert_called_once_with(2, mock_desc())
+
+
+class DedupePerAuthorTestCase(TestCase):
+
+    """
+    TestCase class for testing the one_per_author feature
+    """
+
+    def setUp(self):
+        self.job_url = 'http://localhost:8080/fakejenkins'
+        self.user = 'ausername'
+        self.api_key = 'apikey'
+        job = JenkinsJob(self.job_url, self.user, self.api_key)
+        self.deduper = GhprbOutdatedBuildAborter(job, one_per_author=True)
+
+    @patch('jenkins.job.JenkinsJob.stop_build', return_value=True)
+    @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
+    def test_stop_per_author_no_duplicates(self, update_desc, stop_build):
+        sample_build_data = sample_data(
+            [Pr('2', author='foo').dict, Pr('2', author='bar').dict], [])
+        build_data = self.deduper.get_running_builds(sample_build_data)
+        self.deduper.stop_duplicates(build_data)
+        self.assertFalse(stop_build.called)
+
+    @patch('jenkins.job.JenkinsJob.stop_build', return_value=True)
+    @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
+    def test_stop_per_author_no_duplicates_by_pr(self, update_desc,
+                                                 stop_build):
+        sample_build_data = sample_data(
+            [Pr('2', author='foo').dict, Pr('3', author='foo').dict], [])
+        build_data = self.deduper.get_running_builds(sample_build_data)
+        self.deduper.stop_duplicates(build_data)
+        self.assertFalse(stop_build.called)
+
+    @patch('jenkins.job.JenkinsJob.stop_build', return_value=True)
+    @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
+    def test_stop_per_author_with_duplicates(self, update_desc, stop_build):
+        sample_build_data = sample_data(
+            [Pr('2', author='foo').dict, Pr('2', author='foo').dict], [])
+        build_data = self.deduper.get_running_builds(sample_build_data)
+        self.deduper.stop_duplicates(build_data)
+        stop_build.assert_called_once_with(1)

--- a/jenkins/tests/test_job.py
+++ b/jenkins/tests/test_job.py
@@ -2,11 +2,12 @@ from mock import patch
 from requests.exceptions import HTTPError
 from unittest import TestCase
 
-from jenkins.tests.helpers import mock_response, sample_data
+from jenkins.tests.helpers import mock_response, sample_data, Pr
 from jenkins.job import JenkinsJob
 
 
 class JenkinsJobTestCase(TestCase):
+
     """
     TestCase class for testing deduper.py.
     """
@@ -18,7 +19,7 @@ class JenkinsJobTestCase(TestCase):
         self.job = JenkinsJob(self.job_url, self.user, self.api_key)
 
     def test_get_json_ok(self):
-        data = sample_data(['1'], [])
+        data = sample_data([Pr('1').dict], [])
         with patch('requests.get', return_value=mock_response(200, data)):
             response = self.job.get_json()
             self.assertEqual(data, response)

--- a/jenkins/timeout.py
+++ b/jenkins/timeout.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class BuildTimeout:
+
     """
     A class for programatically finding and aborting stuck builds.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,4 @@ coverage==3.7.1
 nose==1.3.4
 pep8==1.5.7
 pylint==1.4.3
+mock==1.0.1


### PR DESCRIPTION
This defaults to False. If set to True, it will leave one build running for each unique last commit author for a PR.

@clytwynec 