### PR TITLE
accurately count number of master executors

### DIFF
--- a/jenkins/tests/test_workers.py
+++ b/jenkins/tests/test_workers.py
@@ -13,7 +13,8 @@ sample_comp_data = {
     "totalExecutors": 38,
     'computer': [{
         'offline': False,
-        'displayName': 'worker-tag (i-abcd1234)'
+        'displayName': 'worker-tag (i-abcd1234)',
+        'numExecutors': '1',
     }],
 }
 


### PR DESCRIPTION
@benpatterson  This is a small fix for an issue where the number of master executors was being reported incorrectly.