### PR TITLE
Change deduper message 

### DIFF
--- a/jenkins/deduper.py
+++ b/jenkins/deduper.py
@@ -41,8 +41,8 @@ class GhprbOutdatedBuildAborter:
 
         :Returns: A description (string)
         """
-        return ("[PR #{}] Build automatically aborted because"
-                " there is a newer build for the same PR. See build"
+        return ("[PR #{}] You have a newer build running for this PR."
+                " Go see its results instead! Build"
                 " #{}.".format(pr, current_build_id))
 
     def abort_duplicate_builds(self):


### PR DESCRIPTION
@clytwynec @benpatterson 
@sarina @andy-armstrong 

What should we change the text to so that people will be less likely to repeatedly kick off new builds before the new ones are finished? (Assuming we can through some other means get them to at least glance at the aborted build's description.)

Note we can actually use HTML tags if we want.
