### PR TITLE
Fix basic auth envar usage for sitespeed

### DIFF
--- a/jenkins/freestyle/get-sitespeed-report.sh
+++ b/jenkins/freestyle/get-sitespeed-report.sh
@@ -28,7 +28,7 @@ mkdir sitespeed-result
 
 # create a file with the session credential cookie
 ARGS="edx-sitespeed/edx_sitespeed/edx_sitespeed.py -e ${EDX_USER} -p ${EDX_PASS} -u ${TEST_URL}"
-if [ -n "$USE_BASIC_AUTH" ] ;
+if [ $USE_BASIC_AUTH == "True" ] ;
     then ARGS="${ARGS} --auth_user ${AUTH_USER} --auth_pass ${AUTH_PASS}"
 fi
 echo "Recording the session cookie for a logged-in user"
@@ -38,7 +38,7 @@ python ${ARGS}
 # use firefox as a browser with browsertime/browsermobproxy to get waterfalls etc
 ARGS="-u ${TEST_URL} --requestHeaders cookie.json --junit --suppressDomainFolder --outputFolderName results --screenshot --storeJson"
 ARGS="${ARGS} -b ${SITESPEED_BROWSER} -d 0 -n ${NUMBER_OF_TIMES} --connection ${CONNECTION}"
-if [ -n "$USE_BASIC_AUTH" ] ;
+if [ $USE_BASIC_AUTH == "True" ] ;
     then ARGS="${ARGS} --basicAuth ${AUTH_USER}:${AUTH_PASS}"
 fi
 


### PR DESCRIPTION
@benpatterson I realize you caught this in the original code review, and I answered you incorrectly. :(

This should now work by forcing you to have the envar set to [something](https://github.com/edx/testeng-ci/blob/672f3e910e7ba47a55136d6cee25165573bd034d/jenkins/freestyle/get-sitespeed-report.sh#L20) and then only if that string is "True" (os environment variables are always string type) will it pass the credentials through to the scripts.