### PR TITLE
Add ENV_VARS to bok-choy build flow.

### DIFF
--- a/jenkins/flow/master/edx-platform-bok-choy-master.groovy
+++ b/jenkins/flow/master/edx-platform-bok-choy-master.groovy
@@ -7,7 +7,7 @@ def jenkinsUrl = build.environment.get("JENKINS_URL")
 def jobUrl = jenkinsUrl + build.url
 
 try{
-  def statusJobparams = [
+  def statusJobParams = [
     new StringParameterValue("GITHUB_ORG", "edx"),
     new StringParameterValue("GITHUB_REPO", "edx-platform"),
     new StringParameterValue("GIT_SHA", "${sha1}"),
@@ -21,7 +21,7 @@ try{
   statusJob.scheduleBuild2(
       0,
       new Cause.UpstreamCause(build),
-      new ParametersAction(statusJobparams)
+      new ParametersAction(statusJobParams)
   )
 
   println "Triggered github-build-status"

--- a/jenkins/flow/master/edx-platform-bok-choy-master.groovy
+++ b/jenkins/flow/master/edx-platform-bok-choy-master.groovy
@@ -7,7 +7,7 @@ def jenkinsUrl = build.environment.get("JENKINS_URL")
 def jobUrl = jenkinsUrl + build.url
 
 try{
-  def statusJobParams = [
+  def statusJobparams = [
     new StringParameterValue("GITHUB_ORG", "edx"),
     new StringParameterValue("GITHUB_REPO", "edx-platform"),
     new StringParameterValue("GIT_SHA", "${sha1}"),
@@ -21,7 +21,7 @@ try{
   statusJob.scheduleBuild2(
       0,
       new Cause.UpstreamCause(build),
-      new ParametersAction(statusJobParams)
+      new ParametersAction(statusJobparams)
   )
 
   println "Triggered github-build-status"
@@ -29,31 +29,31 @@ try{
   guard{
     parallel(
         {
-          bok_choy_1 = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_1 = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_1)
         },
         {
-          bok_choy_2 = build('edx-platform-test-subset', sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_2 = build('edx-platform-test-subset', sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_2)
         },
         {
-          bok_choy_3 = build('edx-platform-test-subset', sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_3 = build('edx-platform-test-subset', sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_3)
         },
         {
-          bok_choy_4 = build('edx-platform-test-subset', sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_4 = build('edx-platform-test-subset', sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_4)
         },
         {
-          bok_choy_5 = build('edx-platform-test-subset', sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_5 = build('edx-platform-test-subset', sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_5)
         },
         {
-          bok_choy_6 = build('edx-platform-test-subset', sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_6 = build('edx-platform-test-subset', sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_6)
         },
         {
-          bok_choy_7 = build('edx-platform-test-subset', sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number)
+          bok_choy_7 = build('edx-platform-test-subset', sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_7)
         },
     )


### PR DESCRIPTION
The subset job has been updated to include the ENV_VARS parameter.

That parameter is a comma-delimited set of environment variables that will be set using the [EnvInject Plugin](https://wiki.jenkins-ci.org/display/JENKINS/EnvInject+Plugin). The parameter string is parsed and individual environment variables are set in the environment by using the groovy utility of that plugin.

Using this approach, the parent job (build flow job) can receive those parameters to pass down to the child jobs. 

This means we can set various important environment variables as needed for running bok-choy. The best example is setting the SELENIUM_BROWSER variable to something else, or likewise passing the new accessibility-related settings.

@clytwynec @jzoldak could you review? 

An example of this is [here for your inspection](https://build.testeng.edx.org/view/All/job/edx-platform-bok-choy-bjp/21/). Notice that this is testing in chrome, which is analogous to a hard-coded set of jobs [here](https://build.testeng.edx.org/view/All/job/edx-platform-on-chrome).

CC @raeeschachar 