### PR TITLE
Add the script for posting github build status and deployments

### DIFF
--- a/jenkins/freestyle/github-build-status.sh
+++ b/jenkins/freestyle/github-build-status.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+
+echo "POSTing the request for GitHub to create a new status."
+echo "Response from GitHub:"
+curl \
+-s -S --retry 3 \
+-H "Authorization: token $GITHUB_OAUTH_TOKEN" \
+-d '{"state": "'"$BUILD_STATUS"'", "target_url": "'"$TARGET_URL"'", "description": "'"$DESCRIPTION"'", "context": "'"$CONTEXT"'"}' \
+https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/statuses/$GIT_SHA
+
+# If this is a passing master build of any of the contexts, they will signal via
+# the CREATE_DEPLOYMENT variable that we should try to create a new deployment.
+# Each of the contexts will attempt this, but the new deployment will be created
+# only after ALL of the contexts reports in as passed. (In effect, after the
+# last one passes.)
+if [ "$CREATE_DEPLOYMENT" == 'true' ]
+then
+    echo "POSTing the request for GitHub to create a new deployment."
+    echo "Response from GitHub:"
+    curl \
+    -s -S --retry 3 \
+    -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
+    -d '{"ref": "'"$GIT_SHA"'", "environment": "ci", "auto_merge": false, "required_contexts": ["jenkins/a11y", "jenkins/bokchoy", "jenkins/js", "jenkins/lettuce", "jenkins/python", "jenkins/quality"]}' \
+    https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/deployments
+fi


### PR DESCRIPTION
@benpatterson 

The job does not use the script programmatically.
Just sticking it here so that it's under source control.