### PR TITLE
Ensure only latest statuses are used. Add find-commit helper switch.

### DIFF
--- a/release/create_candidate_pr.py
+++ b/release/create_candidate_pr.py
@@ -49,7 +49,6 @@ def _build_parser():
     )
     result.add_argument(
         '--org',
-        nargs=1,
         default='edx',
         help="""
         Specify a github organization to work under. Default is 'edx'.
@@ -57,10 +56,19 @@ def _build_parser():
     )
     result.add_argument(
         '--repo',
-        nargs=1,
         default='edx-platform',
         help="""
         Specify a github repository to work with. Default is 'edx-platform'.
+        """
+    )
+
+    result.add_argument(
+        '--find-commit',
+        action='store_true',
+        default=False,
+        help="""
+        Do not create a branch or a pull request. Only return the commit
+        that would be used for the release candidate.
         """
     )
 
@@ -81,6 +89,14 @@ def create_candidate_main(raw_args):
         commit_hash = commit['sha']
         commit_message = commit['commit']['message']
         message = utils.extract_message_summary(commit_message)
+        if args.find_commit:
+            logger.info(
+                "\n\thash: {commit_hash}\n\tcommit message: {message}".format(
+                    commit_hash=commit_hash,
+                    message=message
+                    )
+                )
+            return
     except utils.NoValidCommitsError:
         logger.error(
             "Couldn't find a recent commit without test failures. Aborting"

--- a/release/github_api.py
+++ b/release/github_api.py
@@ -134,7 +134,7 @@ class GithubApi(object):
     def commit_statuses(self, commit_sha):
         """
         Calls GitHub's '<commit>/statuses' endpoint for a given commit. See
-        https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref
+        https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
 
         Returns:
             list: A list of commit statuses
@@ -142,7 +142,7 @@ class GithubApi(object):
         Raises:
             RequestFailed: If the response fails validation.
         """
-        path = "repos/{org}/{repo}/commits/%s/statuses" % commit_sha
+        path = "repos/{org}/{repo}/commits/%s/status" % commit_sha
         return self._get(path)
 
     def commits(self):

--- a/release/tests/test_github_api.py
+++ b/release/tests/test_github_api.py
@@ -41,7 +41,7 @@ ENDPOINTS = [
     ),
     EndpointInfo(
         "https://api.github.com/repos/test-org/test-repo/commits" +
-        "/sample_hash/statuses",
+        "/sample_hash/status",
         lambda api: api.commit_statuses('sample_hash')
     ),
     EndpointInfo(

--- a/release/tests/test_utils.py
+++ b/release/tests/test_utils.py
@@ -70,29 +70,38 @@ class ReleaseUtilsTestCase(TestCase):
         next_week = date + timedelta(weeks=1)
         self.assertTrue(date < next_week)
 
-    def test_no_good_commits(self):
+    def test_no_parseable_commit_data(self):
         """
-        Tests that if there are no commits that passed checks then we abort
+        Tests that if the JSON data we get back from Github is not parseable,
+        then we abort
         """
         commits_mock = Mock()
         commits_mock.return_value = [{'sha': 'a'}, {'sha': 'b'}]
 
         commit_statuses_mock = Mock()
         commit_statuses_mock.side_effect = [
-            {
-                'statuses':
-                    [
-                        {'state': 'failed'},
-                        {'state': 'failed'},
-                    ]
-            },
-            {
-                'statuses':
-                    [
-                        {'state': 'failed'},
-                        {'state': 'failed'},
-                    ]
-            }
+            {},
+            {'foo': 'bar'},
+        ]
+
+        api = Mock(GithubApi)
+        api.commits = commits_mock
+        api.commit_statuses = commit_statuses_mock
+
+        with self.assertRaises(utils.NoValidCommitsError):
+            utils.most_recent_good_commit(api)
+
+    def test_no_good_commits(self):
+        """
+        Tests that when there are no commits that passed checks, we abort
+        """
+        commits_mock = Mock()
+        commits_mock.return_value = [{'sha': 'a'}, {'sha': 'b'}]
+
+        commit_statuses_mock = Mock()
+        commit_statuses_mock.side_effect = [
+            {'state': 'failure'},
+            {'state': 'pending'},
         ]
 
         api = Mock(GithubApi)
@@ -111,63 +120,14 @@ class ReleaseUtilsTestCase(TestCase):
 
         commit_statuses_mock = Mock()
         commit_statuses_mock.side_effect = [
-            {
-                'statuses':
-                    [
-                        {'state': 'failed'},
-                        {'state': 'failed'},
-                    ]
-            },
+            {'state': 'failure'},
             {},
-            {
-                    'statuses':
-                    [
-                        {'state': 'success', 'context': 'contextA'},
-                        {'state': 'success', 'context': 'contextC'},
-                    ]
-                }
+            {'state': 'success'},
         ]
 
         api = Mock(GithubApi)
         api.commits = commits_mock
         api.commit_statuses = commit_statuses_mock
 
-        # patch the number of successful test suites that need to pass
-        utils.NUMBER_OF_TEST_SUITES = 2
         commit = utils.most_recent_good_commit(api)
         self.assertEquals(commit['sha'], 'c')
-
-    def test_good_commits_but_not_enough(self):
-        """
-        Tests that we properly return the last valid commit
-        """
-        commits_mock = Mock()
-        commits_mock.return_value = [{'sha': 'a'}, {'sha': 'b'}, {'sha': 'c'}]
-
-        commit_statuses_mock = Mock()
-        commit_statuses_mock.side_effect = [
-            {
-                'statuses':
-                    [
-                        {'state': 'failed'},
-                        {'state': 'failed'},
-                    ]
-            },
-            {},
-            {
-                'statuses':
-                    [
-                        {'state': 'success'},
-                        {'state': 'failed'},
-                    ]
-            }
-        ]
-
-        api = Mock(GithubApi)
-        api.commits = commits_mock
-        api.commit_statuses = commit_statuses_mock
-
-        # patch the number of successful test suites that need to pass
-        utils.NUMBER_OF_TEST_SUITES = 2
-        with self.assertRaises(utils.NoValidCommitsError):
-            utils.most_recent_good_commit(api)

--- a/release/utils.py
+++ b/release/utils.py
@@ -7,9 +7,6 @@ import string
 _TUESDAY = 1
 _NORMAL_RELEASE_WEEKDAY = _TUESDAY
 
-# Number of test suites we run on a PR
-NUMBER_OF_TEST_SUITES = 6
-
 
 class NoValidCommitsError(Exception):
     """
@@ -56,18 +53,9 @@ def most_recent_good_commit(github_api):
         commits whose tests haven't started yet are not valid.
         """
         commit_status = github_api.commit_statuses(commit_sha)
-        try:
-            statuses = commit_status['statuses']
 
-            # Determine if all statuses are success
-            passed_tests = all(
-                status['state'] == 'success' for status in statuses
-            )
-
-            return len(statuses) == NUMBER_OF_TEST_SUITES and passed_tests
-        # If JSON can't be parsed, we assume it is not a viable commit
-        except KeyError:
-            return False
+        # Determine if the commit has passed all checks
+        return commit_status.get('state') == 'success'
 
     commits = github_api.commits()
 

--- a/release/utils.py
+++ b/release/utils.py
@@ -55,12 +55,19 @@ def most_recent_good_commit(github_api):
         Ensures there is at least one status update so that
         commits whose tests haven't started yet are not valid.
         """
-        statuses = github_api.commit_statuses(commit_sha)
+        commit_status = github_api.commit_statuses(commit_sha)
+        try:
+            statuses = commit_status['statuses']
 
-        # Determine if all statuses are success
-        passed_tests = all(status['state'] == 'success' for status in statuses)
+            # Determine if all statuses are success
+            passed_tests = all(
+                status['state'] == 'success' for status in statuses
+            )
 
-        return len(statuses) == NUMBER_OF_TEST_SUITES and passed_tests
+            return len(statuses) == NUMBER_OF_TEST_SUITES and passed_tests
+        # If JSON can't be parsed, we assume it is not a viable commit
+        except KeyError:
+            return False
 
     commits = github_api.commits()
 


### PR DESCRIPTION
By using this API endpoint, we will only see the latest statuses
for a given commit. New documentation ref added as part of this
commit.

Add find-commit switch, which will not create a branch or a
pull request; it will only output the commit that will be used.