### PR TITLE
Fix issue checking out correct revision

### DIFF
--- a/mobile_app/checkout_build_repos.py
+++ b/mobile_app/checkout_build_repos.py
@@ -63,8 +63,7 @@ def checkout_repos(build_environment_path, environ, base_path):
         origin_branch = repo.remotes.origin.refs[revision]
         # need to create a local tracking branch of the remote
         # so we can check it out properly
-        repo.create_head(revision)
-        repo.refs[revision].set_tracking_branch(origin_branch)
+        repo.create_head(revision, origin_branch)
         repo.refs[revision].checkout()
         logger.info("switching to branch %s", revision)
 


### PR DESCRIPTION
There was a problem where the new local branch wouldn't actually be
checked out to the remote HEAD of that branch, since we set the tracking
branch after creating the branch, the local HEAD wouldn't be the same as
the remote HEAD.