### PR TITLE
Fix the date argument handling

### DIFF
--- a/release/create_candidate_pr.py
+++ b/release/create_candidate_pr.py
@@ -12,6 +12,7 @@ the most recent commit to master that passed all the tests
 from __future__ import print_function
 
 import argparse
+import datetime
 import logging
 import sys
 
@@ -20,6 +21,16 @@ from release.github_api import GithubApi, RequestFailed
 from release import utils
 
 logger = logging.getLogger(__name__)
+
+
+def valid_date(s):
+    """Convert a string into a date, for argument parsing."""
+    # from: http://stackoverflow.com/a/25470943/14343
+    try:
+        return datetime.datetime.strptime(s, "%Y-%m-%d")
+    except ValueError:
+        msg = "Not a valid date: '{0}'.".format(s)
+        raise argparse.ArgumentTypeError(msg)
 
 
 def _build_parser():
@@ -39,7 +50,7 @@ def _build_parser():
 
     result.add_argument(
         '--release-date',
-        nargs=1,
+        type=valid_date,
         default=expected_date,
         help="""
         Specify a date that the release branch is expected to be deployed.


### PR DESCRIPTION
The old code wouldn't accept a date as advertised:
```
$ python -m release.create_candidate_pr --org edx --repo edx-platform --release-date 2016-03-03
2016-02-26 14:42:23,644 [INFO] Getting GitHub token...
2016-02-26 14:42:23,644 [INFO] Read saved token
2016-02-26 14:42:23,891 [INFO] Authenticated nedbat
2016-02-26 14:42:23,891 [INFO] Fetching commits...
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/src/edx/src/testeng-ci/release/create_candidate_pr.py", line 134, in <module>
    create_candidate_main(sys.argv[1:])
  File "/src/edx/src/testeng-ci/release/create_candidate_pr.py", line 105, in create_candidate_main
    branch_name = utils.rc_branch_name_for_date(args.release_date.date())
AttributeError: 'list' object has no attribute 'date'
```