### PR TITLE
Revert "Pylint fixes for jenkins.build, .job, and .deduper"

### DIFF
--- a/jenkins/build.py
+++ b/jenkins/build.py
@@ -4,7 +4,7 @@ A class for working with the build info returned from the jenkins job API
 import logging
 
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Build(dict):
@@ -15,7 +15,6 @@ class Build(dict):
         build (dict): build data from Jenkins
     """
     def __init__(self, build):
-        super(Build, self).__init__()
         self.isbuilding = build.get('building')
 
         author = None
@@ -24,14 +23,13 @@ class Build(dict):
         if actions:
             action_parameters = actions[0].get('parameters')
             if action_parameters:
-                for param in action_parameters:
-                    if param.get('name') == u'ghprbActualCommitAuthorEmail':
-                        author = param.get('value')
-                    if param.get('name') == u'ghprbPullId':
-                        pr_id = param.get('value')
+                for p in action_parameters:
+                    if p.get('name') == u'ghprbActualCommitAuthorEmail':
+                        author = p.get('value')
+                    if p.get('name') == u'ghprbPullId':
+                        pr_id = p.get('value')
             else:
-
-                LOGGER.debug(
+                logger.debug(
                     "Couldn't find build parameters for build #{}".format(
                         build.get('number')
                     )

--- a/jenkins/job.py
+++ b/jenkins/job.py
@@ -4,13 +4,13 @@ A class to interact with a jenkins job API
 import logging
 import requests
 
-from jenkins.helpers import append_url
+from helpers import append_url
 
 
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
-class JenkinsJob(object):
+class JenkinsJob:
 
     """
     A class for interacting with the jenkins job API
@@ -22,7 +22,7 @@ class JenkinsJob(object):
     """
 
     logging.basicConfig(format='[%(levelname)s] %(message)s')
-    LOGGER = logging.getLogger(__name__)
+    logger = logging.getLogger(__name__)
     logging.getLogger('requests').setLevel('ERROR')
 
     def __init__(self, job_url, username, token):
@@ -75,7 +75,7 @@ class JenkinsJob(object):
             },
         )
 
-        LOGGER.info("Updating description for build #{}. Response: {}".format(
+        logger.info("Updating description for build #{}. Response: {}".format(
             build_id, response.status_code))
 
         response.raise_for_status()
@@ -93,7 +93,7 @@ class JenkinsJob(object):
 
         response = requests.post(url, auth=self.auth)
 
-        LOGGER.info("Aborting build #{}. Response: {}".format(
+        logger.info("Aborting build #{}. Response: {}".format(
             build_id, response.status_code))
 
         response.raise_for_status()


### PR DESCRIPTION
Reverting edx/testeng-ci#61 because the deduper is now failing like this when run on Jenkins: 
```
00:00:05.265 Checking for extra builds of edx-platform-bok-choy-pr job...
00:00:05.305 Traceback (most recent call last):
00:00:05.305   File "jenkins/deduper.py", line 13, in <module>
00:00:05.306     from jenkins.job import JenkinsJob
00:00:05.306 ImportError: No module named jenkins.job
00:00:05.334 Build step 'Execute shell' marked build as failure
```

We don't really need to back out all the changes, but want to get the deduper back in action as quickly as possible as Jenkins is under water at the moment.
