### PR TITLE
Modify Bokchoy Shard Script

### DIFF
--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -9,39 +9,39 @@ def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 guard{
   parallel(
     {
-      bok_choy_1 = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_1 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_1)
     },
     {
-      bok_choy_2 = build('edx-platform-test-subset', sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_2 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_2)
     },
     {
-      bok_choy_3 = build('edx-platform-test-subset', sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_3 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_3)
     },
     {
-      bok_choy_4 = build('edx-platform-test-subset', sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_4 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_4)
     },
     {
-      bok_choy_5 = build('edx-platform-test-subset', sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_5 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_5)
     },
     {
-      bok_choy_6 = build('edx-platform-test-subset', sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_6 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_6)
     },
     {
-      bok_choy_7 = build('edx-platform-test-subset', sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_7 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_7)
     },
     {
-      bok_choy_8 = build('edx-platform-test-subset', sha1: sha1, SHARD: "8", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_8 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "8", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_8)
     },
     {
-      bok_choy_9 = build('edx-platform-test-subset', sha1: sha1, SHARD: "9", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_9 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "9", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_9)
     },
   )

--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -9,39 +9,39 @@ def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 guard{
   parallel(
     {
-      bok_choy_1 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_1 = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_1)
     },
     {
-      bok_choy_2 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_2 = build(subsetJob, sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_2)
     },
     {
-      bok_choy_3 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_3 = build(subsetJob, sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_3)
     },
     {
-      bok_choy_4 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_4 = build(subsetJob, sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_4)
     },
     {
-      bok_choy_5 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_5 = build(subsetJob, sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_5)
     },
     {
-      bok_choy_6 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_6 = build(subsetJob, sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_6)
     },
     {
-      bok_choy_7 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_7 = build(subsetJob, sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_7)
     },
     {
-      bok_choy_8 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "8", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_8 = build(subsetJob, sha1: sha1, SHARD: "8", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_8)
     },
     {
-      bok_choy_9 = build(subsetJob + 'TEST', sha1: sha1, SHARD: "9", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
+      bok_choy_9 = build(subsetJob, sha1: sha1, SHARD: "9", TEST_SUITE: "bok-choy", PARENT_BUILD: "PR Build #" + build.number)
       toolbox.slurpArtifacts(bok_choy_9)
     },
   )

--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -4,7 +4,6 @@ import hudson.model.*
 def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("ghprbActualCommit")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
-def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 
 guard{
   parallel(
@@ -47,6 +46,6 @@ guard{
   )
 }rescue{
   FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
-  FilePath copyToDir = new FilePath(build.workspace, repoName)
+  FilePath copyToDir = new FilePath(build.workspace, "edx-platform")
   artifactsDir.copyRecursiveTo(copyToDir)
 }

--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -4,6 +4,7 @@ import hudson.model.*
 def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("ghprbActualCommit")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
+def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 
 guard{
   parallel(
@@ -46,6 +47,6 @@ guard{
   )
 }rescue{
   FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
-  FilePath copyToDir = new FilePath(build.workspace, "edx-platform")
+  FilePath copyToDir = new FilePath(build.workspace, repoName)
   artifactsDir.copyRecursiveTo(copyToDir)
 }

--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -3,6 +3,8 @@ import hudson.model.*
 
 def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("ghprbActualCommit")
+def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
+def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 
 guard{
   parallel(
@@ -45,6 +47,6 @@ guard{
   )
 }rescue{
   FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
-  FilePath copyToDir = new FilePath(build.workspace, "edx-platform")
+  FilePath copyToDir = new FilePath(build.workspace, repoName)
   artifactsDir.copyRecursiveTo(copyToDir)
 }


### PR DESCRIPTION
@benpatterson @estute @jzoldak 

I changed 2 parts of the script to be more flexible to different testing situations. 
1) Instead of hardcoding the edx-platform-test-subset into the script, it receives it as an environment variable that is injected by the bok-choy-pr job. However, it does default to edx-platform-test-subset
2) Instead of hardcoding that the files are copied to the edx-platform directory, it also receives this as an environment variable that is injected by the bok-choy-pr job. It defaults to edx-platform. 

The PR to accordingly modify bok-choy-pr job is https://github.com/edx/jenkins-job-dsl/pull/19