### PR TITLE
Refactor for ReDeployment

### DIFF
--- a/jenkins/flow/master/edx-platform-bok-choy-master.groovy
+++ b/jenkins/flow/master/edx-platform-bok-choy-master.groovy
@@ -5,6 +5,8 @@ def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("GIT_COMMIT")
 def jenkinsUrl = build.environment.get("JENKINS_URL")
 def jobUrl = jenkinsUrl + build.url
+def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
+def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 
 try{
   def statusJobParams = [
@@ -33,45 +35,45 @@ try{
   guard{
     parallel(
         {
-          bok_choy_1 = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_1 = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_1)
         },
         {
-          bok_choy_2 = build('edx-platform-test-subset', sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_2 = build(subsetJob, sha1: sha1, SHARD: "2", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_2)
         },
         {
-          bok_choy_3 = build('edx-platform-test-subset', sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_3 = build(subsetJob, sha1: sha1, SHARD: "3", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_3)
         },
         {
-          bok_choy_4 = build('edx-platform-test-subset', sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_4 = build(subsetJob, sha1: sha1, SHARD: "4", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_4)
         },
         {
-          bok_choy_5 = build('edx-platform-test-subset', sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_5 = build(subsetJob, sha1: sha1, SHARD: "5", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_5)
         },
         {
-          bok_choy_6 = build('edx-platform-test-subset', sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_6 = build(subsetJob, sha1: sha1, SHARD: "6", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_6)
         },
         {
-          bok_choy_7 = build('edx-platform-test-subset', sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_7 = build(subsetJob, sha1: sha1, SHARD: "7", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_7)
         },
         {
-          bok_choy_8 = build('edx-platform-test-subset', sha1: sha1, SHARD: "8", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_8 = build(subsetJob, sha1: sha1, SHARD: "8", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_8)
         },
         {
-          bok_choy_9 = build('edx-platform-test-subset', sha1: sha1, SHARD: "9", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
+          bok_choy_9 = build(subsetJob, sha1: sha1, SHARD: "9", TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(bok_choy_9)
         },
     )
   }rescue{
     FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
-    FilePath copyToDir = new FilePath(build.workspace, "edx-platform")
+    FilePath copyToDir = new FilePath(build.workspace, repoName)
     artifactsDir.copyRecursiveTo(copyToDir)
   }
 }

--- a/jenkins/flow/master/edx-platform-lettuce-master.groovy
+++ b/jenkins/flow/master/edx-platform-lettuce-master.groovy
@@ -5,12 +5,13 @@ def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("GIT_COMMIT")
 def jenkinsUrl = build.environment.get("JENKINS_URL")
 def jobUrl = jenkinsUrl + build.url
-
+def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
+def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 
 try{
   def statusJobParams = [
     new StringParameterValue("GITHUB_ORG", "edx"),
-    new StringParameterValue("GITHUB_REPO", "edx-platform"),
+    new StringParameterValue("GITHUB_REPO", repoName),
     new StringParameterValue("GIT_SHA", "${sha1}"),
     new StringParameterValue("BUILD_STATUS", "pending"),
     new StringParameterValue("TARGET_URL", jobUrl),
@@ -30,17 +31,17 @@ try{
   guard{
     parallel(
         {
-          lettuce_lms = build('edx-platform-test-subset', sha1: sha1, SHARD: "all", TEST_SUITE: "lms-acceptance", PARENT_BUILD: "master #" + build.number)
+          lettuce_lms = build(subsetJob, sha1: sha1, SHARD: "all", TEST_SUITE: "lms-acceptance", PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(lettuce_lms)
         },
         {
-          lettuce_cms = build('edx-platform-test-subset', sha1: sha1, SHARD: "all", TEST_SUITE: "cms-acceptance", PARENT_BUILD: "master #" + build.number)
+          lettuce_cms = build(subsetJob, sha1: sha1, SHARD: "all", TEST_SUITE: "cms-acceptance", PARENT_BUILD: "master #" + build.number)
           toolbox.slurpArtifacts(lettuce_cms)
         },
     )
   }rescue{
     FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
-    FilePath copyToDir = new FilePath(build.workspace, "edx-platform")
+    FilePath copyToDir = new FilePath(build.workspace, repoName)
     artifactsDir.copyRecursiveTo(copyToDir)
   }
 }

--- a/jenkins/flow/master/edx-platform-python-unittests-master.groovy
+++ b/jenkins/flow/master/edx-platform-python-unittests-master.groovy
@@ -5,6 +5,8 @@ def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("GIT_COMMIT")
 def jenkinsUrl = build.environment.get("JENKINS_URL")
 def jobUrl = jenkinsUrl + build.url
+def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
+def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 
 try{
   def statusJobParams = [
@@ -32,27 +34,27 @@ try{
   guard{
     unit = parallel(
       {
-        lms_unit_1 = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
+        lms_unit_1 = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
         toolbox.slurpArtifacts(lms_unit_1)
       },
       {
-        lms_unit_2 = build('edx-platform-test-subset', sha1: sha1, SHARD: "2", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
+        lms_unit_2 = build(subsetJob, sha1: sha1, SHARD: "2", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
         toolbox.slurpArtifacts(lms_unit_2)
       },
       {
-        lms_unit_3 = build('edx-platform-test-subset', sha1: sha1, SHARD: "3", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
+        lms_unit_3 = build(subsetJob, sha1: sha1, SHARD: "3", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
         toolbox.slurpArtifacts(lms_unit_3)
       },
       {
-        lms_unit_4 = build('edx-platform-test-subset', sha1: sha1, SHARD: "4", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
+        lms_unit_4 = build(subsetJob, sha1: sha1, SHARD: "4", TEST_SUITE: "lms-unit", PARENT_BUILD: "master #" + build.number)
         toolbox.slurpArtifacts(lms_unit_4)
       },
       {
-        cms_unit = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "cms-unit", PARENT_BUILD: "master #" + build.number)
+        cms_unit = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "cms-unit", PARENT_BUILD: "master #" + build.number)
         toolbox.slurpArtifacts(cms_unit)
       },
       {
-        commonlib_unit = build('edx-platform-test-subset', sha1: sha1, SHARD: "1", TEST_SUITE: "commonlib-unit", PARENT_BUILD: "master #" + build.number)
+        commonlib_unit = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "commonlib-unit", PARENT_BUILD: "master #" + build.number)
         toolbox.slurpArtifacts(commonlib_unit)
       },
     )
@@ -82,7 +84,7 @@ try{
     }
   }rescue{
     FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
-    FilePath copyToDir = new FilePath(build.workspace, "edx-platform")
+    FilePath copyToDir = new FilePath(build.workspace, repoName)
     artifactsDir.copyRecursiveTo(copyToDir)
   }
 }


### PR DESCRIPTION
@benpatterson @jzoldak @estute 
This goes along with https://github.com/edx/jenkins-job-dsl/pull/21.

The changes made were to call the appropriate test-subset job rather than hard coding one subset  job and to copy a repo specific directory