### PR TITLE
Benp/capture duration times

### DIFF
--- a/travis/build_info.py
+++ b/travis/build_info.py
@@ -41,7 +41,7 @@ def get_repos(org):
     return repo_list
 
 
-def get_active_builds(org, repo):
+def get_builds(org, repo, is_finished=False):
     """
     Returns list of active builds for a given repo slug
     """
@@ -50,11 +50,16 @@ def get_active_builds(org, repo):
         BASE_URL + 'repos/{repo_slug}/builds'.format(repo_slug=repo_slug)
     )
     build_list = req.json()
-    active_build_list = []
+    selected_build_list = []
     for build in build_list:
-        if build.get('state') != 'finished':
-            active_build_list.append(build)
-    return active_build_list
+        if not is_finished:
+            if build.get('state') != 'finished':
+                selected_build_list.append(build)
+        else:
+            if build.get('state') == 'finished':
+                selected_build_list.append(build)
+
+    return selected_build_list
 
 
 def get_active_jobs(build_id):
@@ -132,7 +137,7 @@ def get_job_counts(org):
 
     repos = get_repos(org)
     for repo in repos:
-        repo_builds = get_active_builds(org, repo)
+        repo_builds = get_builds(org, repo)
         repo_jobs = 0
         repo_started_jobs = 0
         for build in repo_builds:
@@ -163,7 +168,7 @@ def get_build_counts(org):
     org_build_started_count = 0
 
     for repo in repos:
-        repo_builds = get_active_builds(org, repo)
+        repo_builds = get_builds(org, repo)
         logger.debug("--->" + repo)
 
         repo_build_total, num_started = repo_active_build_count(repo_builds)

--- a/travis/tests/fixtures/builds_response.list
+++ b/travis/tests/fixtures/builds_response.list
@@ -1,0 +1,8 @@
+[{ "id": 1, "state": "finished", "result": 0, "number": 10, "duration": 6000 },
+{ "id": 2, "state": "started", "number": 11 },
+{ "id": 3, "state": "finished", "result": 0, "number": 12, "duration": 500 },
+{ "id": 4, "state": "finished", "result": 0, "number": 13, "duration": 540 },
+{ "id": 5, "state": "finished", "result": 0, "number": 14, "duration": 600 },
+{ "id": 6, "state": "finished", "result": 0, "number": 15, "duration": 700 },
+{ "id": 7, "state": "queued", "number": 16 },
+{ "id": 8, "state": "finished", "result": 0, "number": 17, "duration": 650 }]

--- a/travis/tests/test_build_info.py
+++ b/travis/tests/test_build_info.py
@@ -1,17 +1,21 @@
 """
 Tests for testeng-ci/travis/build_info
 """
+from ddt import ddt, data
 from mock import patch
 from testfixtures import LogCapture
 from unittest import TestCase
 
 import httpretty
+import os
 import requests
 
 from travis.build_info import (
     get_repos,
     get_active_jobs,
+    get_average_build_duration,
     get_builds,
+    get_last_n_successful_builds,
     BASE_URL,
     main,
     active_job_counts,
@@ -190,6 +194,17 @@ class TestTravisFinishedBuildInfo(TestCase):
         self.assertEqual(2, len(builds))
 
     @httpretty.activate
+    def test_all_finished_but_asking_for_active(self):
+        httpretty.register_uri(
+            httpretty.GET,
+            self.url_endpoint,
+            body="""[{"id": 1, "state": "finished"},
+                {"id": 2, "state": "finished"}]""",
+        )
+        builds = get_builds('foo', 'bar-repo')
+        self.assertEqual(0, len(builds))
+
+    @httpretty.activate
     def test_all_active(self):
         httpretty.register_uri(
             httpretty.GET,
@@ -197,8 +212,8 @@ class TestTravisFinishedBuildInfo(TestCase):
             body="""[{"id": 1, "state": "started"},
                 {"id": 2, "state": "created"}]""",
         )
-        builds = get_builds('foo', 'bar-repo', is_finished=True)
-        self.assertEqual(0, len(builds))
+        builds = get_builds('foo', 'bar-repo')
+        self.assertEqual(2, len(builds))
 
 
 class TestTravisBuildInfoJobs(TestCase):
@@ -301,9 +316,78 @@ class TestTravisBuildInfoJobs(TestCase):
         self.assertEqual(2, started_jobs_count)
 
 
+@ddt
+class TestTravisSuccessfulBuilds(TestCase):
+    """
+    Test successful build data capture
+    """
+
+    def setUp(self):
+        super(TestTravisSuccessfulBuilds, self).setUp()
+        self.url_endpoint = BASE_URL + 'repos/foo/bar-repo/builds'
+
+    @data(
+        {"requested": 5, "expected": 5},
+        {"requested": 7, "expected": 6},  # the max found in the file is 6
+
+    )
+    @httpretty.activate
+    def test_successful_builds(self, test_data):
+        httpretty.register_uri(
+            httpretty.GET,
+            self.url_endpoint,
+            body=self._load_mock_builds_response_file(
+                "fixtures/builds_response.list"
+            ),
+        )
+
+        successful_builds = get_last_n_successful_builds(
+            'foo',
+            'bar-repo',
+            test_data['requested']
+        )
+        self.assertEquals(len(successful_builds), test_data['expected'])
+
+    def _load_mock_builds_response_file(self, filename):
+        """
+        returns the contents of the specified text fixture/file
+        """
+        test_dir = os.path.dirname(__file__)
+        abs_file = os.path.join(test_dir, filename)
+        with open(abs_file, 'r') as test_file:
+            contents = test_file.read()
+
+        return contents
+
+
+class TestBuildDurationCalculation(TestCase):
+    """
+    test build duration calculation, such as average
+      build duration
+    """
+
+    def test_average_build_duration_returns_minutes(self):
+        builds = [
+            {'id': 1, 'duration': 60}
+        ]
+        self.assertEqual(get_average_build_duration(builds), 1)
+
+    def test_average_duration_whole_numbers(self):
+        """
+        Average number would give a float, but the method
+        returns a whole number
+        """
+        builds = [
+            {'id': 1, 'duration': 600},
+            {'id': 2, 'duration': 600},
+            {'id': 3, 'duration': 660}
+        ]
+        self.assertEqual(get_average_build_duration(builds), 10)
+
+
 class TestTravisBuildInfoMain(TestCase):
     """
-    Test CLI args, etc
+    Test CLI args, and output, output formatting, etc
     """
 
     def setUp(self):
@@ -354,6 +438,33 @@ class TestTravisBuildInfoMain(TestCase):
                 ('travis.build_info', 'INFO', 'overall_total=1'),
                 ('travis.build_info', 'INFO', 'overall_started=1'),
                 ('travis.build_info', 'INFO', 'overall_queued=0')
+            )
+
+    @patch(
+        'travis.build_info.get_builds',
+        return_value=[
+            {
+                "id": 1,
+                "state": "finished",
+                "result": 0,
+                "number": 10,
+                "duration": 600
+            }
+        ]
+        )
+    def test_main_duration(self, _mock_builds):
+        args = [
+            '--org', self.org,
+            '--task-class', 'duration'
+        ]
+        with LogCapture() as log_capture:
+            main(args)
+            log_capture.check(
+                (
+                    'travis.build_info',
+                    'INFO',
+                    "[{'repo': 'bar', 'average duration': 10}]"
+                )
             )
 
     def test_main_debug(self):


### PR DESCRIPTION
work in progress at this point.

Example output:

>
[{'repo': u'edx-app-ios', 'average duration': 65}, {'repo': u'django-oscar', 'average duration': 65}, {'repo': u'bok-choy', 'average duration': 25}, {'repo': u'edx-app-android', 'average duration': 21}, {'repo': u'configuration', 'average duration': 20}, {'repo': u'edx-analytics-dashboard', 'average duration': 16}, {'repo': u'ecommerce', 'average duration': 13}, {'repo': u'edx-notifications', 'average duration': 9}, {'repo': u'edx-ora2', 'average duration': 8}, {'repo': u'edx-ora', 'average duration': 8}, {'repo': u'cs_comments_service', 'average duration': 7}, {'repo': u'edx-drf-extensions', 'average duration': 7}, {'repo': u'edx-documentation', 'average duration': 6}, {'repo': u'auth-backends', 'average duration': 6}, {'repo': u'locust', 'average duration': 6}, {'repo': u'ml-service-api', 'average duration': 6}, {'repo': u'course-discovery', 'average duration': 5}, {'repo': u'ux-pattern-library', 'average duration': 5}, {'repo': u'edx-ui-toolkit', 'average duration': 5}, {'repo': u'diff-cover', 'average duration': 4}, {'repo': u'edx-notes-api', 'average duration': 4}, {'repo': u'ease', 'average duration': 4}, {'repo': u'edx-user-state-client', 'average duration': 4}, {'repo': u'django-oscar-extensions', 'average duration': 4}, {'repo': u'edx-proctoring', 'average duration': 3}, {'repo': u'edx-django-release-util', 'average duration': 3}, {'repo': u'jenkins-job-dsl', 'average duration': 3}, {'repo': u'nose', 'average duration': 3}, {'repo': u'xblock-utils', 'average duration': 3}, {'repo': u'js-test-tool', 'average duration': 3}, {'repo': u'credentials', 'average duration': 3}, {'repo': u'xblock-sdk', 'average duration': 3}, {'repo': u'XBlock', 'average duration': 3}, {'repo': u'discern', 'average duration': 3}, {'repo': u'pa11ycrawler', 'average duration': 2}, {'repo': u'eslint-config-edx', 'average duration': 2}, {'repo': u'edx-analytics-data-api', 'average duration': 2}, {'repo': u'edx-e2e-tests', 'average duration': 2}, {'repo': u'edx-reverification-block', 'average duration': 2}, {'repo': u'opaque-keys', 'average duration': 2}, {'repo': u'edx-lint', 'average duration': 2}, {'repo': u'edx-django-extensions', 'average duration': 2}, {'repo': u'xblock-lti-consumer', 'average duration': 2}, {'repo': u'api-manager', 'average duration': 1}, {'repo': u'xqueue', 'average duration': 1}, {'repo': u'xsy', 'average duration': 1}, {'repo': u'edx-val', 'average duration': 1}, {'repo': u'marketing-site', 'average duration': 1}, {'repo': u'programs', 'average duration': 1}, {'repo': u'cookiecutter-django-ida', 'average duration': 1}, {'repo': u'harprofiler', 'average duration': 1}, {'repo': u'edx-certificates', 'average duration': 1}, {'repo': u'openedx-webhooks', 'average duration': 1}, {'repo': u'edx-analytics-data-api-client', 'average duration': 1}, {'repo': u'edx-organizations', 'average duration': 1}, {'repo': u'edx-search', 'average duration': 1}, {'repo': u'i18n-tools', 'average duration': 1}, {'repo': u'edx-custom-a11y-rules', 'average duration': 1}, {'repo': u'edx-django-sites-extensions', 'average duration': 1}, {'repo': u'django-oauth2-provider', 'average duration': 0}, {'repo': u'tubular', 'average duration': 0}, {'repo': u'edx-gomatic', 'average duration': 0}, {'repo': u'testeng-ci', 'average duration': 0}, {'repo': u'ecommerce-worker', 'average duration': 0}, {'repo': u'edx-load-tests', 'average duration': 0}, {'repo': u'edx-rest-api-client', 'average duration': 0}, {'repo': u'discussions', 'average duration': 0}, {'repo': u'edx-submissions', 'average duration': 0}, {'repo': u'build-pipeline', 'average duration': 0}, {'repo': u'xqueue-watcher', 'average duration': 0}, {'repo': u'event-tracking', 'average duration': 0}, {'repo': u'edx-milestones', 'average duration': 0}, {'repo': u'edx-oauth2-provider', 'average duration': 0}, {'repo': u'repo-tools', 'average duration': 0}, {'repo': u'notifier', 'average duration': 0}, {'repo': u'ccx-keys', 'average duration': 0}, {'repo': u'dummy-webapp', 'average duration': 0}, {'repo': u'edx-sitespeed', 'average duration': 0}]
