### PR TITLE
GoCD modifications to the create PR script

### DIFF
--- a/release/github_api.py
+++ b/release/github_api.py
@@ -117,6 +117,22 @@ class GithubApi(object):
         """
         return self._request(path, 'POST', success_code=201, json=args)
 
+    def _delete(self, path):
+        """
+        Performs a network `DELETE` request, validating its success.
+
+        Arguments:
+            path (string): An api path. Does not need to include the the url
+                domain.
+
+        Returns:
+            json: The output of the endpoint as a json object.
+
+        Raises:
+            RequestFailed: If the response fails validation.
+        """
+        return self._request(path, 'DELETE', success_code=204)
+
     def user(self):
         """
         Calls GitHub's '/user' endpoint.
@@ -159,6 +175,21 @@ class GithubApi(object):
         """
         path = "repos/{org}/{repo}/commits"
         return self._get(path)
+
+    def delete_branch(self, branch_name):
+        """
+        Call GitHub's delete ref (branch) API
+
+        Args:
+            branch_name (str): The name of the branch to delete
+
+        Returns:
+
+        Raises:
+            RequestFailed: If the response fails validation.
+        """
+        path = "repos/{{org}}/{{repo}}/git/refs/{ref}".format(ref=branch_name)
+        return self._delete(path)
 
     def create_branch(self, branch_name, sha):
         """

--- a/release/tests/test_github_api.py
+++ b/release/tests/test_github_api.py
@@ -5,7 +5,7 @@ import ddt
 import json
 import re
 import responses
-from responses import GET, POST  # pylint: disable=no-name-in-module
+from responses import GET, POST, DELETE  # pylint: disable=no-name-in-module
 from unittest import TestCase
 
 from release.tests.aborted import Aborted
@@ -62,6 +62,12 @@ ENDPOINTS = [
             'body': 'more text', 'head': 'branch_name',
             'base': 'base', 'title': 'some request'
         }
+    ),
+    EndpointInfo(
+        "https://api.github.com/repos/test-org/test-repo/git/refs/test-branch",
+        lambda api: api.delete_branch('test-branch'),
+        success=204,
+        method=DELETE
     ),
 ]
 


### PR DESCRIPTION
@doctoryes @benpatterson PTAL. 

This updates the RC creation script to:
- Delete and recreate the release-candidate branch for every release
- make the PR go to: release...release-candidate.

This goes in line with my updating of the release master documentation to use gocd that I am currently working.