### PR TITLE
Remove param that's only used in master jobs.

### DIFF
--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -11,7 +11,7 @@ guard{
     parallel(
       (1..11).collect { index ->
         return {
-          bokchoybuild = build(subsetJob, sha1: sha1, SHARD: index, TEST_SUITE: "bok-choy", ENV_VARS: params["ENV_VARS"], PARENT_BUILD: "master #" + build.number, WORKER_LABEL: workerLabel)
+          bokchoybuild = build(subsetJob, sha1: sha1, SHARD: index, TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number, WORKER_LABEL: workerLabel)
           toolbox.slurpArtifacts(bokchoybuild)
 
           }


### PR DESCRIPTION
Previous merge included this param, which is not used by PR jobs.