### PR TITLE
Update s3 bucket name in README

### DIFF
--- a/lambdas/webhook_forwarder/README.md
+++ b/lambdas/webhook_forwarder/README.md
@@ -11,6 +11,6 @@ Jenkins instance
 To zip and upload a new version, using the aws cli:
 ```
 zip webhook_forwarder.zip webhook_forwarder.py
-aws s3 cp webhook_forwarder.zip s3://edx-testeng-lambda-webhooks/
+aws s3 cp webhook_forwarder.zip s3://edx-tools-lambda-webhooks/
 rm webhook_forwarder.zip
 ```

--- a/lambdas/webhook_processor/README.md
+++ b/lambdas/webhook_processor/README.md
@@ -12,7 +12,7 @@ terraform apply --target aws_s3_bucket.edx-testeng-lambda-webhook
 To zip and upload a new version, using the aws cli:
 ```
 zip webhook_processor.zip webhook_processor.py
-aws s3 cp webhook_processor.zip s3://edx-testeng-lambda-webhook/
+aws s3 cp webhook_processor.zip s3://edx-tools-lambda-webhooks/
 rm webhook_processor.zip
 ```
 


### PR DESCRIPTION
Used to be edx-testeng-lambda-webhook, now its edx-tools-lambda-webhook