### PR TITLE
Add retry for Jenkins triggered builds

### DIFF
--- a/lambdas/webhook_processor/README.md
+++ b/lambdas/webhook_processor/README.md
@@ -11,7 +11,7 @@ terraform apply --target aws_s3_bucket.edx-testeng-lambda-webhook
 
 To zip and upload a new version, using the aws cli:
 ```
-zip webhook_processor.zip webhook_processor.py
+zip webhook_processor.zip webhook_processor.py constants.py
 aws s3 cp webhook_processor.zip s3://edx-tools-lambda-webhooks/
 rm webhook_processor.zip
 ```

--- a/lambdas/webhook_processor/constants.py
+++ b/lambdas/webhook_processor/constants.py
@@ -1,0 +1,68 @@
+# Create constants that hold lists of jobs.
+# These will be used when querying the Jenkins
+# API to ensure all expected jobs have been triggered.
+EDX_PLATFORM_BASE_TESTS = [
+    "-accessibility-",
+    "-bok-choy-",
+    "-js-",
+    "-lettuce-",
+    "-python-unittests-",
+    "-quality-",
+]
+
+# edx-platform tests
+EDX_PLATFORM_MASTER = [
+    "edx-platform" + base + "master"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+EDX_PLATFORM_PR = [
+    "edx-platform" + base + "pr"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+
+EDX_PLATFORM_EUCALYPTUS_MASTER = [
+    "eucalyptus" + base + "master"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+EDX_PLATFORM_EUCALYPTUS_PR = [
+    "eucalyptus" + base + "pr"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+
+EDX_PLATFORM_FICUS_MASTER = [
+    "ficus" + base + "master"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+EDX_PLATFORM_FICUS_PR = [
+    "ficus" + base + "pr"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+
+# edx-platform-private tests
+EDX_PLATFORM_PRIVATE_MASTER = [
+    "edx-platform" + base + "master_private"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+EDX_PLATFORM_PRIVATE_PR = [
+    "edx-platform" + base + "pr_private"
+    for base in EDX_PLATFORM_BASE_TESTS
+]
+
+# edx-e2e-tests
+EDX_E2E_PR = [
+    "microsites-staging-tests-pr",
+    "edx-e2e-tests-pr"
+]
+
+# openedx release branch names
+EUCALYTPUS_BRANCH = "open-release/eucalyptus.master"
+FICUS_BRANCH = "open-release/ficus.master"
+
+# Create dictionary to find the proper credentials
+# file name in S3 based on the Jenkins url.
+# These files must exist in the S3 bucket specified in
+# the webhook-processor environment variable.
+JENKINS_S3_OBJECTS = {
+    "https://build.testeng.edx.org": "testeng_jenkins_credentials",
+    "https://test-jenkins.testeng.edx.org": "testeng_jenkins_credentials"
+}

--- a/lambdas/webhook_processor/constants.py
+++ b/lambdas/webhook_processor/constants.py
@@ -62,7 +62,10 @@ FICUS_BRANCH = "open-release/ficus.master"
 # file name in S3 based on the Jenkins url.
 # These files must exist in the S3 bucket specified in
 # the webhook-processor environment variable.
+#
+# Only keeping build jenkins in here since that
+# is the only one expecting to run jobs for each
+# hook.
 JENKINS_S3_OBJECTS = {
-    "https://build.testeng.edx.org": "edx_tools_core_jenkins_credentials",
-    "https://test-jenkins.testeng.edx.org": "edx_tools_core_jenkins_credentials"
+    "https://build.testeng.edx.org": "edx_tools_core_jenkins_credentials"
 }

--- a/lambdas/webhook_processor/constants.py
+++ b/lambdas/webhook_processor/constants.py
@@ -63,6 +63,6 @@ FICUS_BRANCH = "open-release/ficus.master"
 # These files must exist in the S3 bucket specified in
 # the webhook-processor environment variable.
 JENKINS_S3_OBJECTS = {
-    "https://build.testeng.edx.org": "testeng_jenkins_credentials",
-    "https://test-jenkins.testeng.edx.org": "testeng_jenkins_credentials"
+    "https://build.testeng.edx.org": "edx_tools_core_jenkins_credentials",
+    "https://test-jenkins.testeng.edx.org": "edx_tools_core_jenkins_credentials"
 }

--- a/lambdas/webhook_processor/test/test_webhook_processor.py
+++ b/lambdas/webhook_processor/test/test_webhook_processor.py
@@ -8,7 +8,12 @@ from mock import patch, Mock
 
 from ..webhook_processor import _send_message, _process_results_for_failures
 from ..webhook_processor import _verify_data, _add_gh_header, _get_target_urls
+from ..webhook_processor import _get_num_tries, _parse_executables_for_builds
+from ..webhook_processor import _get_jobs_list, _parse_hook_for_testing_info
+from ..webhook_processor import _builds_contain_tests
+from ..webhook_processor import _get_running_builds, _get_queued_builds
 from ..webhook_processor import lambda_handler
+from ..constants import *
 
 
 class WebhookProcessorTestCase(TestCase):
@@ -47,6 +52,16 @@ class WebhookProcessorTestCase(TestCase):
         urls = _get_target_urls()
         self.assertEqual(urls, ['http://www.a.com/foo',
                                 'http://www.b.com/bar'])
+
+    @patch.dict(os.environ, {'NUM_TRIES': '3'})
+    def test_num_tries(self):
+        num_tries = _get_num_tries()
+        self.assertEqual(num_tries, 3)
+
+    @patch.dict(os.environ, {'NUM_TRIES': 'notanint'})
+    def test_invalid_num_tries(self):
+        with self.assertRaises(StandardError):
+            num_tries = _get_num_tries()
 
     def test_process_results_for_failures(self):
         data = [
@@ -89,12 +104,342 @@ class WebhookProcessorRequestTestCase(TestCase):
             self.assertEqual(exception.message, '500 Server Error: None')
 
 
+class JenkinsRetryTestCase(TestCase):
+    def test_parse_executables_for_builds(self):
+        data = {
+            'actions': [{
+                'parameters': [{
+                    'name': 'sha1',
+                    'value': '12345'
+                }]
+            }],
+            'url': 'https://build.testeng.edx.org'
+                   '/job/edx-platform-bokchoy-pr/1234'
+        }
+        build_status = "running"
+
+        expected_response = [{
+            "job_name": "edx-platform-bokchoy-pr", "sha": "12345"
+        }]
+        actual_response = _parse_executables_for_builds(data, build_status)
+        self.assertEqual(expected_response, actual_response)
+
+    def test_get_jobs_list(self):
+        platform_master_pr_jobs_list = \
+            _get_jobs_list('edx-platform', 'master', 'pull_request', False)
+        self.assertEqual(
+            platform_master_pr_jobs_list, EDX_PLATFORM_PR
+        )
+        platform_master_merge_jobs_list = \
+            _get_jobs_list('edx-platform', 'master', 'pull_request', True)
+        self.assertEqual(
+            platform_master_merge_jobs_list, EDX_PLATFORM_MASTER
+        )
+
+        platform_eucalyptus_pr_jobs_list = \
+            _get_jobs_list('edx-platform', 'eucalyptus', 'pull_request', False)
+        self.assertEqual(
+            platform_eucalyptus_pr_jobs_list, EDX_PLATFORM_EUCALYPTUS_PR
+        )
+        platform_eucalyptus_merge_jobs_list = \
+            _get_jobs_list('edx-platform', 'eucalyptus', 'pull_request', True)
+        self.assertEqual(
+            platform_eucalyptus_merge_jobs_list, EDX_PLATFORM_EUCALYPTUS_MASTER
+        )
+
+        platform_ficus_pr_jobs_list = \
+            _get_jobs_list('edx-platform', 'ficus', 'pull_request', False)
+        self.assertEqual(
+            platform_ficus_pr_jobs_list, EDX_PLATFORM_FICUS_PR
+        )
+        platform_ficus_merge_jobs_list = \
+            _get_jobs_list('edx-platform', 'ficus', 'pull_request', True)
+        self.assertEqual(
+            platform_ficus_merge_jobs_list, EDX_PLATFORM_FICUS_MASTER
+        )
+
+        platform_private_pr_jobs_list = \
+            _get_jobs_list('edx-platform-private', '', 'pull_request', False)
+        self.assertEqual(
+            platform_private_pr_jobs_list, EDX_PLATFORM_PRIVATE_PR
+        )
+        platform_private_merge_jobs_list = \
+            _get_jobs_list('edx-platform-private', '', 'pull_request', True)
+        self.assertEqual(
+            platform_private_merge_jobs_list, EDX_PLATFORM_PRIVATE_MASTER
+        )
+
+        e2e_pr_jobs_list = \
+            _get_jobs_list('edx-e2e-tests', '', 'pull_request', False)
+        self.assertEqual(
+            e2e_pr_jobs_list, EDX_E2E_PR
+        )
+
+        empy_jobs_list = \
+            _get_jobs_list('dummy_repo', '', 'pull_request', False)
+        self.assertEqual(
+            empy_jobs_list, []
+        )
+
+    @patch('webhook_processor.webhook_processor._get_jobs_list',
+           return_value={})
+    def test_parse_hook_with_master_open_pr(self, jobs_list_mock):
+        data = {
+            'action': 'opened',
+            'pull_request': {
+                'head': {
+                    'sha': '12345',
+                },
+                'base': {
+                    'ref': 'master',
+                    'repo': {
+                        'name': 'edx-platform'
+                    }
+                },
+                'merged': False
+            }
+        }
+        event_type = 'pull_request'
+        sha, _ = _parse_hook_for_testing_info(data, event_type)
+        self.assertEqual(sha, '12345')
+        jobs_list_mock.assert_called_with(
+            'edx-platform',
+            'master',
+            'pull_request',
+            False
+        )
+
+    @patch('webhook_processor.webhook_processor._get_jobs_list',
+           return_value={})
+    def test_parse_hook_with_eucalyptus_open_pr(self, jobs_list_mock):
+        data = {
+            'action': 'opened',
+            'pull_request': {
+                'head': {
+                    'sha': '12345',
+                },
+                'base': {
+                    'ref': 'open-release/eucalyptus.master',
+                    'repo': {
+                        'name': 'edx-platform'
+                    }
+                },
+                'merged': False
+            }
+        }
+        event_type = 'pull_request'
+        sha, _ = _parse_hook_for_testing_info(data, event_type)
+        self.assertEqual(sha, '12345')
+        jobs_list_mock.assert_called_with(
+            'edx-platform',
+            'eucalyptus',
+            'pull_request',
+            False
+        )
+
+    @patch('webhook_processor.webhook_processor._get_jobs_list',
+           return_value={})
+    def test_parse_hook_with_ficus_open_pr(self, jobs_list_mock):
+        data = {
+            'action': 'opened',
+            'pull_request': {
+                'head': {
+                    'sha': '12345',
+                },
+                'base': {
+                    'ref': 'open-release/ficus.master',
+                    'repo': {
+                        'name': 'edx-platform'
+                    }
+                },
+                'merged': False
+            }
+        }
+        event_type = 'pull_request'
+        sha, _ = _parse_hook_for_testing_info(data, event_type)
+        self.assertEqual(sha, '12345')
+        jobs_list_mock.assert_called_with(
+            'edx-platform',
+            'ficus',
+            'pull_request',
+            False
+        )
+
+    @patch('webhook_processor.webhook_processor._get_jobs_list',
+           return_value={})
+    def test_parse_hook_with_merge_pr(self, jobs_list_mock):
+        data = {
+            'action': 'closed',
+            'pull_request': {
+                'base': {
+                    'ref': 'master',
+                    'repo': {
+                        'name': 'edx-platform'
+                    }
+                },
+                'merge_commit_sha': '67890',
+                'merged': True
+            }
+        }
+        event_type = 'pull_request'
+        sha, _ = _parse_hook_for_testing_info(data, event_type)
+        self.assertEqual(sha, '67890')
+        jobs_list_mock.assert_called_with(
+            'edx-platform',
+            'master',
+            'pull_request',
+            True
+        )
+
+    @patch('webhook_processor.webhook_processor._get_jobs_list',
+           return_value={})
+    def test_parse_hook_with_closed_pr(self, jobs_list_mock):
+        data = {
+            'action': 'closed',
+            'pull_request': {
+                'base': {
+                    'ref': 'master',
+                    'repo': {
+                        'name': 'edx-platform'
+                    }
+                },
+                'merge_commit_sha': '67890',
+                'merged': False
+            }
+        }
+        event_type = 'pull_request'
+        sha, jobs_list = _parse_hook_for_testing_info(data, event_type)
+        self.assertEqual(sha, None)
+        self.assertEqual(jobs_list, None)
+        jobs_list_mock.assert_not_called()
+
+    @patch('webhook_processor.webhook_processor._get_jobs_list',
+           return_value={})
+    def test_parse_hook_with_non_pr(self, jobs_list_mock):
+        data = {
+            'body': {
+                'zen': 'Non-blocking is better than blocking.',
+                'hook_id': 12341234,
+                'hook': {
+                    'type': 'Repository',
+                    'id': 98765432,
+                    'events': ['issue_comment', 'pull_request']
+                },
+                'repository': {'id': 12341234, 'name': 'foo'},
+                'sender': {'id': 12345678},
+            },
+            'headers': {'X-GitHub-Event': 'ping'}
+        }
+        event_type = 'ping'
+        sha, jobs_list = _parse_hook_for_testing_info(data, event_type)
+        self.assertEqual(sha, None)
+        self.assertEqual(jobs_list, None)
+        jobs_list_mock.assert_not_called()
+
+    def test_builds_contain_tests_true(self):
+        builds = [{
+            'job_name': 'edx-platform-bok-choy-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-accessibility-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-js-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-lettuce-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-python-unittests-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-quality-pr',
+            'sha': '12345'
+        }]
+        sha = '12345'
+        jobs_list = EDX_PLATFORM_PR
+
+        self.assertEqual(True, _builds_contain_tests(builds, sha, jobs_list))
+
+    def test_builds_contain_tests_false(self):
+        builds = [{
+            'job_name': 'edx-platform-bok-choy-pr',
+            'sha': '56789'
+        }, {
+            'job_name': 'edx-platform-accessibility-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-js-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-lettuce-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-python-unittests-pr',
+            'sha': '12345'
+        }, {
+            'job_name': 'edx-platform-quality-pr',
+            'sha': '12345'
+        }]
+        sha = '12345'
+        jobs_list = EDX_PLATFORM_PR
+
+        self.assertEqual(False, _builds_contain_tests(builds, sha, jobs_list))
+
+    def test_builds_contain_tests_empty(self):
+        builds = []
+        sha = '12345'
+        jobs_list = []
+
+        self.assertEqual(True, _builds_contain_tests(builds, sha, jobs_list))
+
+    @staticmethod
+    def mock_running_response():
+        data = {
+            'computer': [{
+                'executors': [{
+                    'currentExecutable': {
+                        'actions': [{
+                            'parameters': [{
+                                'name': 'sha1',
+                                'value': '12345'
+                            }]
+                        }],
+                        'url': 'https://build.testeng.edx.org'
+                               '/job/edx-platform-bokchoy-pr/1234'
+                        }
+                }],
+                'oneOffExecutors': []
+            }]
+        }
+        return data
+
+    @patch('webhook_processor.webhook_processor.get',
+           return_value=Response())
+    def test_get_running_builds(self, json_mock):
+        with patch(
+            'botocore.vendored.requests.models.Response.json',
+            return_value=self.mock_running_response()
+        ):
+            expected_response = [
+                {"job_name": "edx-platform-bokchoy-pr", "sha": "12345"}
+            ]
+
+            url = 'https://www.jenkins.org'
+            username = 'username'
+            token = 'password'
+            actual_response = _get_running_builds(url, username, token)
+            self.assertEqual(expected_response, actual_response)
+
+
 class LambdaHandlerTestCase(TestCase):
+    @patch('webhook_processor.webhook_processor._get_num_tries',
+           return_value=3)
     @patch('webhook_processor.webhook_processor._get_target_urls',
            return_value=['http://www.example.com'])
     @patch('webhook_processor.webhook_processor._send_message',
            return_value={})
-    def test_lambda_handler(self, send_msg_mock, _url_mock):
+    def test_lambda_handler(self, send_msg_mock, _url_mock, _num_tries_mock):
         data = {
             'body': {
                 'zen': 'Non-blocking is better than blocking.',
@@ -130,3 +475,58 @@ class LambdaHandlerTestCase(TestCase):
             data.get('body'),
             {'Content-Type': 'application/json', 'X-GitHub-Event': u'ping'}
         )
+
+    @patch('webhook_processor.webhook_processor._get_num_tries',
+           return_value=3)
+    @patch('webhook_processor.webhook_processor._get_target_urls',
+           return_value=[
+               'https://build.testeng.edx.org',
+               'https://www.notjenkins.com'
+           ])
+    @patch('webhook_processor.webhook_processor._send_message',
+           return_value={})
+    @patch('webhook_processor.webhook_processor._parse_hook_for_testing_info',
+           return_value=('12345', ['edx-platform-accessibility-pr']))
+    @patch('webhook_processor.webhook_processor._all_tests_triggered',
+           side_effect=[False, False, True])
+    def test_lambda_handler_retry(
+        self, tests_trig_mock, testing_info_mock, send_msg_mock,
+        _url_mock, _num_tries_mock
+    ):
+        data = {
+            'body': {
+                'action': 'opened',
+                'pull_request': {
+                    'head': {
+                        'sha': '12345',
+                    },
+                    'base': {
+                        'ref': 'master',
+                        'repo': {
+                            'name': 'edx-platform'
+                        }
+                    },
+                    'merged': False
+                }
+            },
+            'headers': {'X-GitHub-Event': 'pull_request'}
+        }
+
+        event = {
+            'Records': [{
+                'kinesis': {
+                    'SequenceNumber': 'n',
+                    'ApproximateArrivalTimestamp': 12345,
+                    'data': base64.b64encode(json.dumps(data)),
+                    'PartitionKey': '1'
+                }
+            }],
+            'NextShardIterator': 'abc',
+            'MillisBehindLatest': 0
+        }
+
+        lambda_handler(event, None)
+
+        # one url has no jenkins jobs, and the mock will have the other
+        # fail the first 2 times. so ensure 4 total messages sent
+        self.assertEqual(send_msg_mock.call_count, 4)

--- a/lambdas/webhook_processor/webhook_processor.py
+++ b/lambdas/webhook_processor/webhook_processor.py
@@ -276,10 +276,10 @@ def _get_jobs_list(repository, target, event_type, is_merge):
                 jobs_list = EDX_PLATFORM_PRIVATE_MASTER
             else:
                 jobs_list = EDX_PLATFORM_PRIVATE_PR
-    elif repository == 'edx-e2e-tests':
-        if event_type == 'pull_request':
-            if not is_merge:
-                jobs_list = EDX_E2E_PR
+    # elif repository == 'edx-e2e-tests':
+    #     if event_type == 'pull_request':
+    #         if not is_merge:
+    #             jobs_list = EDX_E2E_PR
 
     return jobs_list
 

--- a/lambdas/webhook_processor/webhook_processor.py
+++ b/lambdas/webhook_processor/webhook_processor.py
@@ -2,9 +2,14 @@ import base64
 import json
 import logging
 import os
+import re
+from six.moves.urllib.parse import urlparse
+from constants import *
 
-from botocore.vendored.requests import post
+import botocore.session
+from botocore.vendored.requests import post, get
 
+logging.basicConfig()
 logger = logging.getLogger()
 
 # First log the function load message, then change
@@ -24,7 +29,6 @@ def _get_target_urls():
     """
     Get the target URLs for the processed hooks from a comma delimited
     list of URLs, set in an OS environment variable.
-
     Return a list of target URLs
     """
     url = os.environ.get('TARGET_URLS')
@@ -32,6 +36,55 @@ def _get_target_urls():
         raise StandardError('Environment variable TARGET_URLS was not set')
 
     return url.split(',')
+
+
+def _get_num_tries():
+    """
+    Get the number of tries desired. If Jenkins does not trigger
+    all of the expected jobs on the first try, the webhook will be resent
+    until this number is hit.
+    Return a integer
+    """
+    num_tries_string = os.environ.get('NUM_TRIES')
+
+    try:
+        num_tries_int = int(num_tries_string)
+    except:
+        raise StandardError(
+            'Environment variable NUM_TRIES was not set to a valid integer'
+        )
+
+    return num_tries_int
+
+
+def _get_credentials_from_s3(jenkins_url):
+    """
+    Get jenkins credentials from s3 bucket.
+    The bucket name should be an environment variable, and the
+    object name should be specified in a dict (with the
+    Jenkins url as the key) in the constants.py file.
+    The expected object is a JSON file formatted as:
+    {
+        "username": "sampleusername",
+        "api_token": "sampletoken"
+    }
+    """
+    session = botocore.session.get_session()
+    client = session.create_client('s3')
+
+    bucket_name = os.environ.get('S3_CREDENTIALS_BUCKET')
+
+    if not bucket_name:
+        raise StandardError(
+            'Environment variable S3_CREDENTIALS_BUCKET was not set'
+        )
+
+    file_name = JENKINS_S3_OBJECTS[jenkins_url] + '.json'
+
+    creds_file = client.get_object(Bucket=bucket_name, Key=file_name)
+    creds = json.loads(creds_file['Body'].read())
+
+    return creds["username"], creds["api_token"]
 
 
 def _verify_data(data_string):
@@ -57,7 +110,6 @@ def _add_gh_header(data_object, headers):
     """
     Get the X-GitHub-Event header from the original request
     data, add this to the headers, and return the results.
-
     Raise an error if the GitHub event header is not found.
     """
     gh_headers = data_object.get('headers')
@@ -127,6 +179,224 @@ def _process_results_for_failures(results):
     return results_count
 
 
+def _parse_hook_for_testing_info(payload, event_type):
+    """
+    Parse the webhook to find the commit sha,
+    as well as the arguments needed to find the
+    jobs_list.
+    Returns:
+        Tuple with commit sha and list of jobs that
+        should be triggered. If the event type is not
+        pull_request, return empty values
+    """
+    ignore = False
+
+    if event_type == 'pull_request':
+        # find the repo and whether the pr is being merged
+        repository = payload['pull_request']['base']['repo']['name']
+        is_merge = payload['pull_request']['merged']
+
+        # check if the base branch is an openedx release branch
+        base_ref = payload['pull_request']['base']['ref']
+        if base_ref == EUCALYTPUS_BRANCH:
+            target = "eucalyptus"
+        elif base_ref == FICUS_BRANCH:
+            target = "ficus"
+        else:
+            target = "master"
+
+        if payload['action'] == 'closed':
+            sha = payload['pull_request']['merge_commit_sha']
+            if not is_merge:
+                # if the PR was closed and not merged,
+                # no jobs will be triggered
+                ignore = True
+        else:
+            # PR was either opened or "synchronized"
+            sha = payload['pull_request']['head']['sha']
+    else:
+        # unsupported event type, return None for both values
+        ignore = True
+
+    # if we are ignoring this hook, return None values,
+    # otherwise, return sha, jobs_list
+    if ignore:
+        # we don't care about these so assign None, None
+        sha, jobs_list = (None, None)
+    else:
+        # find the jobs list for this hook
+        jobs_list = _get_jobs_list(repository, target, event_type, is_merge)
+
+    return sha, jobs_list
+
+
+def _get_jobs_list(repository, target, event_type, is_merge):
+    """
+    Find the list of jobs that the webhook should kick
+    off on Jenkins.
+    """
+    jobs_list = []
+    if repository == 'edx-platform':
+        if event_type == 'pull_request':
+            if target == 'master':
+                if is_merge:
+                    jobs_list = EDX_PLATFORM_MASTER
+                else:
+                    jobs_list = EDX_PLATFORM_PR
+            if target == 'eucalyptus':
+                if is_merge:
+                    jobs_list = EDX_PLATFORM_EUCALYPTUS_MASTER
+                else:
+                    jobs_list = EDX_PLATFORM_EUCALYPTUS_PR
+            if target == 'ficus':
+                if is_merge:
+                    jobs_list = EDX_PLATFORM_FICUS_MASTER
+                else:
+                    jobs_list = EDX_PLATFORM_FICUS_PR
+    elif repository == 'edx-platform-private':
+        if event_type == 'pull_request':
+            if is_merge:
+                jobs_list = EDX_PLATFORM_PRIVATE_MASTER
+            else:
+                jobs_list = EDX_PLATFORM_PRIVATE_PR
+    elif repository == 'edx-e2e-tests':
+        if event_type == 'pull_request':
+            if not is_merge:
+                jobs_list = EDX_E2E_PR
+
+    return jobs_list
+
+
+def _all_tests_triggered(jenkins_url, sha, jobs_list):
+    """
+    Check to see if the sha has triggered each
+    job in the jobs_list. Looks at both the queue
+    as well as currently running builds
+    """
+    jenkins_username, jenkins_token = _get_credentials_from_s3(jenkins_url)
+
+    queued = _get_queued_builds(
+        jenkins_url, jenkins_username, jenkins_token
+    )
+    running = _get_running_builds(
+        jenkins_url, jenkins_username, jenkins_token
+    )
+    queued_or_running = queued + running
+
+    return _builds_contain_tests(queued_or_running, sha, jobs_list)
+
+
+def _builds_contain_tests(builds, sha, jobs_list):
+    """
+    From the list of all running/queued builds, check
+    to see if the webhook's sha has kicked off every
+    job in the jobs_list
+    """
+    triggered_jobs = []
+    contain_jobs = True
+    if jobs_list:
+        for build in builds:
+            build_job_name = build['job_name']
+            build_sha = build['sha']
+            if (build_job_name in jobs_list
+                    and build_sha == sha
+                    and build_job_name not in triggered_jobs):
+                triggered_jobs.append(build_job_name)
+        if set(triggered_jobs) != set(jobs_list):
+            contain_jobs = False
+
+    return contain_jobs
+
+
+def _parse_executables_for_builds(executable, build_status):
+    """
+    Parse executable to find the sha and job name of
+    queued/running builds.
+    Return list of jobs with the sha that triggered
+    them
+    """
+    builds = []
+    for action in executable['actions']:
+        if 'parameters' in action:
+            for param in action['parameters']:
+                if (param['name'] == 'sha1' or
+                        param['name'] == 'ghprbActualCommit'):
+                    sha = param['value']
+                    if build_status == 'queued':
+                        job_name = executable['task']['name']
+                    elif build_status == 'running':
+                        url = executable['url']
+                        m = re.search(
+                            r'/job/([^/]+)/.*',
+                            urlparse(url).path
+                        )
+                        job_name = m.group(1)
+                    builds.append({
+                        'job_name': job_name,
+                        'sha': sha
+                    })
+    return builds
+
+
+def _get_queued_builds(jenkins_url, jenkins_username, jenkins_token):
+    """
+    Find all builds currently in the queue
+    """
+    builds = []
+    build_status = 'queued'
+
+    # Use Jenkins REST API to get info on the queue
+    # set a timeout for the request to avoid timing out of lambda
+    url = '%s/queue/api/json?depth=0' % (jenkins_url)
+    try:
+        response = get(
+            url,
+            auth=(jenkins_username, jenkins_token),
+            timeout=3
+        )
+        response_json = response.json()
+
+        # Find all builds in the queue and add them to a list
+        [builds.extend(_parse_executables_for_builds(executable, build_status))
+         for executable in response_json['items']]
+    except:
+        logger.warning('Timed out while trying to access the queue.')
+
+    return builds
+
+
+def _get_running_builds(jenkins_url, jenkins_username, jenkins_token):
+    """
+    Find all builds that are currently running
+    """
+    builds = []
+    build_status = 'running'
+
+    # Use Jenkins REST API to get info on all workers
+    # set a timeout for the request to avoid timing out of lambda
+    url = '%s/computer/api/json?depth=2' % (jenkins_url)
+    try:
+        response = get(
+            url,
+            auth=(jenkins_username, jenkins_token),
+            timeout=6
+        )
+        response_json = response.json()
+
+        # Find all builds being executed and add them to a list
+        for worker in response_json['computer']:
+            for executor in worker['executors'] + worker['oneOffExecutors']:
+                executable = executor['currentExecutable']
+                if executable:
+                    builds.extend(
+                        _parse_executables_for_builds(executable, build_status)
+                    )
+    except:
+        logger.warning('Timed out while trying to access the running builds.')
+
+    return builds
+
+
 def lambda_handler(event, _context):
 
     urls = _get_target_urls()
@@ -164,12 +434,73 @@ def lambda_handler(event, _context):
         payload = data_object.get('body')
         logger.debug("payload is: '{}'".format(payload))
 
+        # Get the sha and jobs list (if applicable), as well as
+        # the max number of retries for sending the hook.
+        event_type = headers.get('X-GitHub-Event')
+        sha, jobs_list = _parse_hook_for_testing_info(payload, event_type)
+        num_tries = _get_num_tries()
+
         # Send it off!
-        # Save up the results for later processing rather than letting
-        # the errors get raised.
+        # If the url is a known jenkins instance (in constants.py),
+        # check to make sure all jobs have been triggered. If they
+        # haven't, continue trying up to "num_tries" times.
+        # Save up the final results for later processing rather than
+        # letting the errors get raised.
         # That way we can process all records and urls.
-        for url in urls:
-            results.append(_send_message(url, payload, headers))
+        for attempt in range(0, num_tries):
+            # rather than retrying one url continuously, and risking
+            # timeout, loop through urls for each retry
+            url_iterator = 0
+            while url_iterator < len(urls):
+                # the url will likely have a path, such as /ghprbhook/,
+                # find just the base_url
+                url_parsed = urlparse(urls[url_iterator])
+                base_url = url_parsed.scheme + '://' + url_parsed.netloc
+
+                # send the message!
+                result = _send_message(urls[url_iterator], payload, headers)
+
+                # Check if base_url is in JENKINS_S3_OBJECTS
+                if base_url in JENKINS_S3_OBJECTS:
+                    if jobs_list:
+                        logger.info(
+                            "Checking if Jenkins jobs have been triggered..."
+                        )
+                        if _all_tests_triggered(base_url, sha, jobs_list):
+                            logger.info(
+                                "All Jenkins jobs have been triggered "
+                                "for sha: '{}'".format(sha)
+                            )
+                            results.append(result)
+                            # url satisifed, delete from list
+                            del urls[url_iterator]
+                        else:
+                            url_iterator += 1
+                            if attempt == num_tries - 1:
+                                # jobs were not all triggered for url
+                                logger.error(
+                                    "Unable to trigger all jobs for "
+                                    "sha: '{}'".format(sha)
+                                )
+                                # no more tries, so save result
+                                results.append(result)
+                            else:
+                                logger.info(
+                                    "Not all Jenking Jobs were triggered. "
+                                    "This webhook will be resent..."
+                                )
+                    else:
+                        logger.info("No Jenkins Jobs expected for this sha.")
+                        # no jobs expected, delete from list
+                        del urls[url_iterator]
+                else:
+                    logger.info("No Jenkins Jobs expected for this url.")
+                    # not a jenkins url, delete from list
+                    del urls[url_iterator]
+            if not len(urls):
+                # if there are no more urls that need jenkins jobs
+                # triggered, no need for more retries
+                break
 
     results_count = _process_results_for_failures(results)
 


### PR DESCRIPTION
This PR allows the webhook_processor to query the Jenkins REST API, and verify that certain PR's accurately trigger all of their respective Jenkins jobs. If some are left out, it is able to resend the webhook up to a desired number of times.