### PR TITLE
Simplify Spigot target and bump POST timeouts

### DIFF
--- a/lambdas/process_webhooks/test/test_process_webhooks.py
+++ b/lambdas/process_webhooks/test/test_process_webhooks.py
@@ -6,10 +6,9 @@ from unittest import TestCase
 from botocore.vendored.requests import Response
 from mock import patch, Mock
 
-from ..process_webhooks import _send_message, _process_results_for_failures
-from ..process_webhooks import _add_gh_header, _get_target_urls
-from ..process_webhooks import _get_target_queue, lambda_handler
-from ..process_webhooks import _is_from_queue
+from ..process_webhooks import _send_message, _add_gh_header
+from ..process_webhooks import _get_target_url, _get_target_queue
+from ..process_webhooks import lambda_handler, _is_from_queue
 
 
 class ProcessWebhooksTestCase(TestCase):
@@ -25,19 +24,10 @@ class ProcessWebhooksTestCase(TestCase):
         with self.assertRaises(ValueError):
             _add_gh_header(test_data, {})
 
-    @patch.dict(os.environ, {'TARGET_URLS': 'http://www.example.com/webhooks'})
-    def test_get_target_urls_single(self):
-        urls = _get_target_urls()
-        self.assertEqual(urls, ['http://www.example.com/webhooks'])
-
-    @patch.dict(
-        os.environ,
-        {'TARGET_URLS': 'http://www.a.com/foo,http://www.b.com/bar'}
-    )
-    def test_get_target_urls_multiple(self):
-        urls = _get_target_urls()
-        self.assertEqual(urls, ['http://www.a.com/foo',
-                                'http://www.b.com/bar'])
+    @patch.dict(os.environ, {'TARGET_URL': 'http://www.example.com/webhooks'})
+    def test_get_target_url(self):
+        url = _get_target_url()
+        self.assertEqual(url, 'http://www.example.com/webhooks')
 
     @patch.dict(os.environ, {'TARGET_QUEUE': 'queue_name'})
     def test_get_target_queue(self):
@@ -58,15 +48,6 @@ class ProcessWebhooksTestCase(TestCase):
         from_queue = _is_from_queue(event)
         self.assertEqual(from_queue, False)
 
-    def test_process_results_for_failures(self):
-        data = [
-            {'response': Mock()},
-            {'exception': Mock()},
-            {'response': Mock()}
-        ]
-        result = _process_results_for_failures(data)
-        self.assertEqual(result, {'failure': 1, 'success': 2})
-
 
 class ProcessWebhooksRequestTestCase(TestCase):
     @staticmethod
@@ -80,23 +61,18 @@ class ProcessWebhooksRequestTestCase(TestCase):
             'process_webhooks.process_webhooks.post',
             return_value=self.mock_response(200)
         ):
-            result = _send_message('http://www.example.com', None, None)
-            response = result.get('response')
+            response = _send_message('http://www.example.com', None, None)
             self.assertIsNotNone(response)
             self.assertEqual(response.status_code, 200)
-            exception = result.get('exception')
-            self.assertIsNone(exception)
 
     def test_send_message_error(self):
         with patch(
             'process_webhooks.process_webhooks.post',
             return_value=self.mock_response(500)
         ):
-            result = _send_message('http://www.example.com', None, None)
-            response = result.get('response')
-            self.assertIsNone(response)
-            exception = result.get('exception')
-            self.assertEqual(exception.message, '500 Server Error: None')
+            with self.assertRaises(StandardError):
+                response = _send_message('http://www.example.com', None, None)
+                self.assertEqual(response.message, '500 Server Error: None')
 
 
 class LambdaHandlerTestCase(TestCase):
@@ -116,8 +92,8 @@ class LambdaHandlerTestCase(TestCase):
         'headers': {'X-GitHub-Event': 'ping'}
     }
 
-    @patch('process_webhooks.process_webhooks._get_target_urls',
-           return_value=['http://www.example.com'])
+    @patch('process_webhooks.process_webhooks._get_target_url',
+           return_value='http://www.example.com')
     @patch('process_webhooks.process_webhooks._send_message',
            return_value={})
     def test_lambda_handler_to_target(self, send_msg_mock, _url_mock):
@@ -129,20 +105,18 @@ class LambdaHandlerTestCase(TestCase):
             {'Content-Type': 'application/json', 'X-GitHub-Event': u'ping'}
         )
 
-    @patch('process_webhooks.process_webhooks._get_target_urls',
-           return_value=['http://www.example.com'])
+    @patch('process_webhooks.process_webhooks._get_target_url',
+           return_value='http://www.example.com')
     @patch('process_webhooks.process_webhooks._send_message',
-           return_value={})
+           side_effect=StandardError("Error!"))
     @patch('process_webhooks.process_webhooks._is_from_queue',
            return_value=False)
     @patch('process_webhooks.process_webhooks._get_target_queue',
            return_value='queue_name')
-    @patch('process_webhooks.process_webhooks._process_results_for_failures',
-           return_value={'failure': 'exception'})
     @patch('process_webhooks.process_webhooks._send_to_queue',
            return_value={})
     def test_lambda_handler_to_target_error(
-        self, send_queue_mock, _results_mock, _queue_mock,
+        self, send_queue_mock, _queue_mock,
         _from_queue_mock, send_msg_mock, _url_mock
     ):
         self.event['spigot_state'] = 'ON'
@@ -163,12 +137,10 @@ class LambdaHandlerTestCase(TestCase):
            return_value='queue_name')
     @patch('process_webhooks.process_webhooks._is_from_queue',
            return_value=False)
-    @patch('process_webhooks.process_webhooks._process_results_for_failures',
-           return_value={'failure': 'exception'})
     @patch('process_webhooks.process_webhooks._send_to_queue',
            return_value={})
     def test_lambda_handler_to_queue(
-        self, send_queue_mock, _results_mock, _from_queue_mock, _queue_mock
+        self, send_queue_mock, _from_queue_mock, _queue_mock
     ):
         self.event['spigot_state'] = 'OFF'
         lambda_handler(self.event, None)
@@ -181,12 +153,10 @@ class LambdaHandlerTestCase(TestCase):
            return_value='queue_name')
     @patch('process_webhooks.process_webhooks._is_from_queue',
            return_value=True)
-    @patch('process_webhooks.process_webhooks._process_results_for_failures',
-           return_value={'failure': 'exception'})
     @patch('process_webhooks.process_webhooks._send_to_queue',
            return_value={})
     def test_lambda_handler_to_queue_from_queue(
-        self, send_queue_mock, _results_mock, _from_queue_mock, _queue_mock
+        self, send_queue_mock, _from_queue_mock, _queue_mock
     ):
         self.event['spigot_state'] = 'OFF'
         with self.assertRaises(StandardError):

--- a/lambdas/send_from_queue/send_from_queue.py
+++ b/lambdas/send_from_queue/send_from_queue.py
@@ -213,7 +213,7 @@ def lambda_handler(event, _context):
                 api_url_query,
                 json=payload,
                 headers=headers,
-                timeout=(3.05, 10)
+                timeout=(3.05, 30)
             )
 
             # If there was a problem, raise an error


### PR DESCRIPTION
Removing support for a list of urls for the target. In the future, we are likely going to replace this with different stages for different jenkins instances.