### PR TITLE
Query Jenkins API for Platform PRs

### DIFF
--- a/lambdas/process_webhooks/README.md
+++ b/lambdas/process_webhooks/README.md
@@ -14,7 +14,7 @@ terraform apply --target aws_s3_bucket.edx-testeng-spigot
 
 To zip and upload a new version, using the aws cli:
 ```
-zip process_webhooks.zip process_webhooks.py
+zip process_webhooks.zip process_webhooks.py constants.py
 aws s3 cp process_webhooks.zip s3://edx-tools-spigot/
 rm process_webhooks.zip
 ```

--- a/lambdas/process_webhooks/constants.py
+++ b/lambdas/process_webhooks/constants.py
@@ -1,0 +1,42 @@
+# Create constants that hold lists of jobs.
+# These will be used when querying the Jenkins
+# API to ensure all expected jobs have been triggered.
+EDX_PLATFORM_CONTEXTS = [
+    "-accessibility-",
+    "-bok-choy-",
+    "-js-",
+    "-lettuce-",
+    "-python-unittests-",
+    "-quality-",
+]
+
+platform_jobs = [
+    "EDX_PLATFORM_PR",
+    "EDX_PLATFORM_FICUS_PR",
+    "EDX_PLATFORM_GINKGO_PR",
+    "EDX_PLATFORM_PRIVATE_PR",
+]
+
+platform_job_names_by_context = [
+    [
+        "edx-platform" + base + "pr",
+        "eucalyptus" + base + "pr",
+        "ficus" + base + "pr",
+        "ginkgo" + base + "pr",
+        "edx-platform" + base + "pr_private",
+    ]
+    for base in EDX_PLATFORM_CONTEXTS
+]
+
+platform_jobs_by_branch_type = list(zip(*platform_job_names_by_context))
+JOBS_DICT = dict(zip(platform_jobs, platform_jobs_by_branch_type))
+
+# OpenEdX release branch names
+RELEASE_BRANCHES = {
+    "refs/heads/open-release/eucalyptus.master": "eucalyptus",
+    "refs/heads/open-release/ficus.master": "ficus",
+    "refs/heads/open-release/ginkgo.master": "ginkgo"
+}
+
+CREDENTIALS_BUCKET = "edx-tools-credentials"
+CREDENTIALS_FILE = "edx_tools_core_jenkins_credentials.json"

--- a/lambdas/process_webhooks/process_webhooks.py
+++ b/lambdas/process_webhooks/process_webhooks.py
@@ -2,9 +2,14 @@ import base64
 import json
 import logging
 import os
+import re
+from six.moves.urllib.parse import urlparse
+from constants import *
+import ast
 
 import boto3
-from botocore.vendored.requests import post
+import botocore.session
+from botocore.vendored.requests import post, get
 
 logger = logging.getLogger()
 
@@ -21,13 +26,10 @@ if not isinstance(numeric_level, int):
 logger.setLevel(numeric_level)
 
 
-def _get_target_url(headers):
+def _get_target_url():
     """
     Get the target URL for the processed hooks from the
-    OS environment variable. Based on the GitHub event,
-    add the proper endpoint.
-
-    Return the target URL with the appropriate endpoint
+    OS environment variable.
     """
     url = os.environ.get('TARGET_URL')
     if not url:
@@ -35,6 +37,14 @@ def _get_target_url(headers):
             "Environment variable TARGET_URL was not set"
         )
 
+    return url
+
+
+def _get_url_endpoint(base_url, headers):
+    """
+    Based on the GitHub event, add the proper endpoint
+    to the target url.
+    """
     event_type = headers.get('X-GitHub-Event')
 
     # Based on the X-Github-Event header, determine the
@@ -53,7 +63,256 @@ def _get_target_url(headers):
             "type: {}".format(event_type)
         )
 
-    return url + "/" + endpoint
+    return base_url + "/" + endpoint
+
+
+def _get_credentials_from_s3(jenkins_url):
+    """
+    Get jenkins credentials from s3 bucket.
+    The expected object is a JSON file formatted as:
+    {
+        "username": "sampleusername",
+        "api_token": "sampletoken"
+    }
+    """
+    # For both build and test jenkins, we can use
+    # the same credentials
+    session = botocore.session.get_session()
+    client = session.create_client('s3')
+
+    creds_file = client.get_object(
+        Bucket=CREDENTIALS_BUCKET,
+        Key=CREDENTIALS_FILE
+    )
+    creds = json.loads(creds_file['Body'].read())
+
+    if not creds.get("username") or not creds.get("api_token"):
+        raise StandardError(
+            'Credentials file needs both a '
+            'username and api_token attribute'
+        )
+
+    return creds["username"], creds["api_token"]
+
+
+def _get_jobs_list(repository, release_target):
+    """
+    Find the list of jobs that the webhook should kick
+    off on Jenkins.
+    """
+    jobs_list = []
+
+    # Based on the repo, target, and event type find the
+    # desired list of tests from constants.py
+    if repository == 'edx-platform':
+        if release_target == 'eucalyptus':
+            jobs_list = JOBS_DICT['EDX_PLATFORM_EUCALYPTUS_PR']
+        elif release_target == 'ficus':
+            jobs_list = JOBS_DICT['EDX_PLATFORM_FICUS_PR']
+        elif release_target == 'ginkgo':
+            jobs_list = JOBS_DICT['EDX_PLATFORM_GINKGO_PR']
+        else:
+            jobs_list = JOBS_DICT['EDX_PLATFORM_PR']
+    elif repository == 'edx-platform-private':
+        jobs_list = JOBS_DICT['EDX_PLATFORM_PRIVATE_PR']
+
+    return jobs_list
+
+
+def _parse_hook_for_testing_info(payload, event_type):
+    """
+    Parse the webhook to find the commit sha,
+    as well as the arguments needed to find the
+    jobs_list.
+    Returns:
+        Tuple with commit sha and list of jobs that
+        should be triggered. If the event type is not
+        pull_request, return empty values
+    """
+    ignore = False
+
+    if event_type == 'pull_request':
+        if payload['action'] != 'closed':
+            # PR was either "opened" or "synchronized" which is
+            # when a new commit is pushed to the PR
+            repository = payload['pull_request']['base']['repo']['name']
+            ref = payload['pull_request']['base']['ref']
+            sha = payload['pull_request']['head']['sha']
+        else:
+            ignore = True
+    else:
+        # Unsupported event type, return None for both values
+        ignore = True
+
+    # Find the release_target based on the base_ref
+    if not ignore:
+        if ref in RELEASE_BRANCHES:
+            # find the target from constants.py
+            release_target = RELEASE_BRANCHES[ref]
+        else:
+            release_target = None
+
+    # If we are ignoring this hook, return None values,
+    # otherwise, return sha, jobs_list
+    if ignore:
+        # We don't care about these so assign None, None
+        return (None, None)
+    else:
+        # Find the jobs list for this hook
+        jobs_list = _get_jobs_list(repository, release_target)
+
+    return sha, jobs_list
+
+
+def _parse_executable_for_builds(
+    executable, build_status, event_type, hook_sha
+):
+    """
+    Parse executable to find the sha and job name of
+    queued/running builds.
+    Return list of jobs with the sha that triggered
+    them
+    """
+    builds = []
+    if event_type == "pull_request":
+        # All PR jobs show the sha that triggered them inside its
+        # parameters.
+        for action in executable['actions']:
+            if 'parameters' in action:
+                for param in action['parameters']:
+                    if (param['name'] == 'sha1' or
+                            param['name'] == 'ghprbActualCommit'):
+                        sha = param['value']
+                        if build_status == 'queued':
+                            job_name = executable['task']['name']
+                        elif build_status == 'running':
+                            url = executable['url']
+                            m = re.search(
+                                r'/job/([^/]+)/.*',
+                                urlparse(url).path
+                            )
+                            job_name = m.group(1)
+                        if sha == hook_sha:
+                            builds.append({
+                                'job_name': job_name,
+                                'sha': sha
+                            })
+
+    return builds
+
+
+def _get_queued_builds(
+    jenkins_url, jenkins_username, jenkins_token, event_type, sha
+):
+    """
+    Find all builds currently in the queue
+    """
+    build_status = 'queued'
+    builds = []
+
+    # Use Jenkins REST API to get info on the queue
+    # set a timeout for the request to avoid timing out of lambda
+    url = '{}/queue/api/json?depth=0'.format(jenkins_url)
+    try:
+        response = get(
+            url,
+            auth=(jenkins_username, jenkins_token),
+            timeout=(3.05, 10)
+        )
+        response_json = response.json()
+
+        # Find all builds in the queue and add them to a list
+        for executable in response_json['items']:
+            builds.extend(
+                _parse_executable_for_builds(
+                    executable, build_status, event_type, sha
+                )
+            )
+    except:
+        logger.warning('Timed out while trying to access the queue.')
+
+    return builds
+
+
+def _get_running_builds(
+    jenkins_url, jenkins_username, jenkins_token, event_type, sha
+):
+    """
+    Find all builds that are currently running
+    """
+    build_status = 'running'
+    builds = []
+
+    # Use Jenkins REST API to get info on all workers
+    # set a timeout for the request to avoid timing out of lambda
+    url = '{}/computer/api/json?depth=2'.format(jenkins_url)
+    try:
+        response = get(
+            url,
+            auth=(jenkins_username, jenkins_token),
+            timeout=(3.05, 10)
+        )
+        response_json = response.json()
+
+        # Find all builds being executed and add them to a list
+        for worker in response_json['computer']:
+            for executor in worker['executors'] + worker['oneOffExecutors']:
+                executable = executor['currentExecutable']
+                if executable:
+                    builds.extend(
+                        _parse_executable_for_builds(
+                            executable, build_status, event_type, sha
+                        )
+                    )
+    except:
+        logger.warning('Timed out while trying to access the running builds.')
+
+    return builds
+
+
+def _get_all_triggered_builds(jenkins_url, event_type, sha):
+    """
+    Check to see if the sha has triggered each
+    job in the jobs_list. Looks at both the queue
+    as well as currently running builds
+    """
+    jenkins_username, jenkins_token = _get_credentials_from_s3(jenkins_url)
+
+    queued = _get_queued_builds(
+        jenkins_url, jenkins_username, jenkins_token, event_type, sha
+    )
+    running = _get_running_builds(
+        jenkins_url, jenkins_username, jenkins_token, event_type, sha
+    )
+    queued_or_running = queued + running
+
+    return queued_or_running
+
+
+def _get_triggered_jobs_from_list(builds, already_triggered, sha, jobs_list):
+    """
+    From the list of all running/queued builds, find which
+    jobs from the jobs_list have been triggered.
+    """
+    triggered_jobs = already_triggered[:]
+    if builds and jobs_list:
+        for build in builds:
+            build_job_name = build['job_name']
+            build_sha = build['sha']
+            if (build_job_name in jobs_list
+                    and build_sha == sha
+                    and build_job_name not in triggered_jobs):
+                triggered_jobs.append(build_job_name)
+
+    return triggered_jobs
+
+
+def _all_jobs_triggered(triggered_jobs, jobs_list):
+    """
+    Check to see if all jobs in the jobs list
+    have been triggered.
+    """
+    return set(triggered_jobs) == set(jobs_list)
 
 
 def _get_target_queue():
@@ -142,6 +401,8 @@ def lambda_handler(event, _context):
 
     # Add the headers from the event
     headers = _add_gh_header(event, header)
+    event.pop('headers')
+    event.update({'headers': headers})
     logger.debug("headers are: '{}'".format(headers))
 
     # Get the state of the spigot from the api variable
@@ -152,13 +413,16 @@ def lambda_handler(event, _context):
 
     if spigot_state == "ON":
         # Get the url that the webhook will be sent to
-        url = _get_target_url(headers)
+        url = _get_target_url()
+        url_with_endpoint = _get_url_endpoint(url, headers)
 
-        if not url:
+        if not url_with_endpoint:
             # If url is None, swallow the hook, since it is just a ping
             return (
                 "Received a ping webhook. No action required."
             )
+
+        event_type = headers.get('X-GitHub-Event')
 
         # We had stored the payload to send in the
         # 'body' node of the data object.
@@ -167,7 +431,7 @@ def lambda_handler(event, _context):
 
         # Send it off!
         try:
-            _result = _send_message(url, payload, headers)
+            _result = _send_message(url_with_endpoint, payload, headers)
         except:
             if not from_queue:
                 # The transmission was a failure, if it's not
@@ -176,10 +440,84 @@ def lambda_handler(event, _context):
                 _response = _send_to_queue(event, queue_name)
             raise StandardError(
                 "There was an error sending the message "
-                "to the url: {}".format(url)
+                "to the url: {}".format(url_with_endpoint)
+            )
+
+        # Get the commit sha and list of expected jobs to be executed
+        # from this webhook.
+        sha, jobs_list = _parse_hook_for_testing_info(
+            payload, event_type
+        )
+
+        # If there is no jobs_list then no Jenkins jobs are expected
+        if not jobs_list:
+            logger.info(
+                "No platform jobs are expected to be triggered "
+                "by this hook."
+            )
+            return (
+                "Webhook successfully sent to "
+                "url: {}".format(url_with_endpoint)
+            )
+
+        # Get all triggered running/ queued builds from Jenkins
+        # that match the desired sha.
+        triggered_builds = _get_all_triggered_builds(
+            url, event_type, sha
+        )
+
+        # Check if this hook has already successfully triggered some jobs.
+        # If so, its possible that the jobs have finished executing since
+        # the hooks first transmission.
+        already_triggered_builds = []
+        if event.get('already_triggered'):
+            already_triggered_builds = ast.literal_eval(
+                event.get('already_triggered')
+            )
+            already_triggered_builds = [
+                str(x) for x in already_triggered_builds
+            ]
+            logger.info(
+                'The following jobs have been previously '
+                'triggered: {}'.format(already_triggered_builds)
+            )
+
+        triggered_jobs_from_list = _get_triggered_jobs_from_list(
+            triggered_builds, already_triggered_builds, sha, jobs_list
+        )
+
+        if _all_jobs_triggered(triggered_jobs_from_list, jobs_list):
+            logger.info(
+                "All Jenkins jobs have been triggered "
+                "for sha: '{}'".format(sha)
+            )
+        else:
+            # Not all tests were triggered, queue this hook
+            # for later processing.
+            if (from_queue and
+                    already_triggered_builds != triggered_jobs_from_list):
+                # The message came from the queue, and not all the expected
+                # jobs have been triggered. However, more jobs were kicked
+                # off, so we need to update that by adding a new hook to the
+                # queue, and deleting the old. Send a unique error message
+                # so send_from_queue knows to delete it despite the error.
+                event.update({'already_triggered': triggered_jobs_from_list})
+                queue_name = _get_target_queue()
+                _response = _send_to_queue(event, queue_name)
+                raise StandardError(
+                    "More jobs triggered, but unable to trigger all jobs."
+                )
+            elif not from_queue:
+                event.update({'already_triggered': triggered_jobs_from_list})
+                queue_name = _get_target_queue()
+                _response = _send_to_queue(event, queue_name)
+            raise StandardError(
+                "Unable to trigger all jobs for "
+                "sha: '{}'".format(sha)
             )
         return (
-            "Webhook successfully sent to url: {}".format(url)
+            "Webhook successfully sent to url: {} and the following jobs "
+            "have been kicked off: {}".format(url_with_endpoint, jobs_list)
         )
     elif spigot_state == "OFF":
         # Since the spigot is off, send the event

--- a/lambdas/process_webhooks/test/test_process_webhooks.py
+++ b/lambdas/process_webhooks/test/test_process_webhooks.py
@@ -7,76 +7,375 @@ from botocore.vendored.requests import Response
 from mock import patch, Mock
 
 from ..process_webhooks import _send_message, _add_gh_header
-from ..process_webhooks import _get_target_url, _get_target_queue
-from ..process_webhooks import lambda_handler, _is_from_queue
+from ..process_webhooks import _get_target_url, _get_url_endpoint
+from ..process_webhooks import _get_target_queue, lambda_handler
+from ..process_webhooks import _is_from_queue, _get_jobs_list
+from ..process_webhooks import _parse_hook_for_testing_info
+from ..process_webhooks import _parse_executable_for_builds
+from ..process_webhooks import _get_running_builds
+from ..process_webhooks import _get_triggered_jobs_from_list
+from ..process_webhooks import _all_jobs_triggered
+
+from ..constants import *
+
+ping_event = {
+    "spigot_state": "",
+    "body": {
+        "zen": "Non-blocking is better than blocking.",
+        "hook_id": 12341234,
+        "hook": {
+            "type": "Repository",
+            "id": 98765432,
+            "events": ["issue_comment", "pull_request"]
+        },
+        "repository": {"id": 12341234, "name": "foo"},
+        "sender": {"id": 12345678},
+    },
+    "headers": {"X-GitHub-Event": "ping"}
+}
+
+push_event = {
+    "spigot_state": "",
+    "body": {
+        "ref": "",
+        "commits": [
+            {
+                "id": "2899e87215f3686c2e6ebb10d60c68ed215f182a"
+            }
+        ],
+        "head_commit": {
+            "id": "2899e87215f3686c2e6ebb10d60c68ed215f182a"
+        },
+        "repository": {
+            "id": 86592256,
+            "name": "edx-platform",
+        },
+        "pusher": {
+            "name": "michaelyoungstrom",
+            "email": "myoungstrom@edx.org"
+        },
+        "sender": {
+            "login": "michaelyoungstrom"
+        }
+    },
+    "headers": {"X-GitHub-Event": "push"}
+}
+
+pr_event = {
+    "spigot_state": "",
+    "body": {
+        "action": "opened",
+        "pull_request": {
+            "id": 129919040,
+            "user": {
+                "login": "michaelyoungstrom",
+                "id": 9468017
+            },
+            "head": {
+                "sha": "2aebed50cfda531dd0c0d3916c084fd26d81362f",
+                "repo": {
+                    "id": 86592256,
+                    "name": "pr_repo"
+                }
+            },
+            "base": {
+                "ref": "master",
+                "sha": "e49b8845ead3a45b8c67c461cf139279e55762c7",
+                "repo": {
+                    "id": 86592256,
+                    "name": "edx-platform",
+                }
+            },
+        },
+        "repository": {
+            "id": 86592256,
+            "name": "pr_repo"
+        }
+    },
+    "headers": {"X-GitHub-Event": "pull_request"}
+}
 
 
 class ProcessWebhooksTestCase(TestCase):
     headers = {
-        'Content-Type': 'application/json',
-        'X-GitHub-Event': ''
+        "Content-Type": "application/json",
+        "X-GitHub-Event": ""
     }
 
-    @patch.dict(os.environ, {'TARGET_URL': 'http://www.example.com'})
-    def test_get_target_url_pr(self):
-        self.headers['X-GitHub-Event'] = 'pull_request'
-        url = _get_target_url(self.headers)
-        self.assertEqual(url, 'http://www.example.com/ghprbhook/')
+    @patch.dict(os.environ, {"TARGET_URL": "http://www.example.com"})
+    def test_get_target_url(self):
+        url = _get_target_url()
+        self.assertEqual(url, "http://www.example.com")
 
-    @patch.dict(os.environ, {'TARGET_URL': 'http://www.example.com'})
-    def test_get_target_url_comment(self):
-        self.headers['X-GitHub-Event'] = 'issue_comment'
-        url = _get_target_url(self.headers)
-        self.assertEqual(url, 'http://www.example.com/ghprbhook/')
+    def test_get_target_url_error(self):
+        with self.assertRaises(StandardError):
+            url = _get_target_url()
 
-    @patch.dict(os.environ, {'TARGET_URL': 'http://www.example.com'})
-    def test_get_target_url_push(self):
-        self.headers['X-GitHub-Event'] = 'push'
-        url = _get_target_url(self.headers)
-        self.assertEqual(url, 'http://www.example.com/github-webhook/')
+    def test_get_url_endpoint_pr(self):
+        self.headers["X-GitHub-Event"] = "pull_request"
+        url = _get_url_endpoint("http://www.example.com", self.headers)
+        self.assertEqual(url, "http://www.example.com/ghprbhook/")
 
-    @patch.dict(os.environ, {'TARGET_URL': 'http://www.example.com'})
-    def test_get_target_url_ping(self):
-        self.headers['X-GitHub-Event'] = 'ping'
-        url = _get_target_url(self.headers)
+    def test_get_url_endpoint_comment(self):
+        self.headers["X-GitHub-Event"] = "issue_comment"
+        url = _get_url_endpoint("http://www.example.com", self.headers)
+        self.assertEqual(url, "http://www.example.com/ghprbhook/")
+
+    def test_get_url_endpoint_push(self):
+        self.headers["X-GitHub-Event"] = "push"
+        url = _get_url_endpoint("http://www.example.com", self.headers)
+        self.assertEqual(url, "http://www.example.com/github-webhook/")
+
+    def test_get_url_endpoint_ping(self):
+        self.headers["X-GitHub-Event"] = "ping"
+        url = _get_url_endpoint("http://www.example.com", self.headers)
         self.assertEqual(url, None)
 
-    @patch.dict(os.environ, {'TARGET_URL': 'http://www.example.com'})
-    def test_get_target_url_error(self):
-        self.headers['X-GitHub-Event'] = 'status'
+    def test_get_url_endpoint_error(self):
+        self.headers["X-GitHub-Event"] = "status"
         with self.assertRaises(StandardError):
-            url = _get_target_url(self.headers)
+            url = _get_url_endpoint("http://www.example.com", self.headers)
 
     def test_add_gh_header(self):
-        gh_header = {'X-GitHub-Event': 'push'}
-        test_data = {'headers': gh_header}
+        gh_header = {"X-GitHub-Event": "push"}
+        test_data = {"headers": gh_header}
         headers = _add_gh_header(test_data, {})
         self.assertEqual(headers, gh_header)
 
     def test_add_gh_header_exception(self):
         gh_header = {}
-        test_data = {'headers': gh_header}
+        test_data = {"headers": gh_header}
         with self.assertRaises(ValueError):
             _add_gh_header(test_data, {})
 
-    @patch.dict(os.environ, {'TARGET_QUEUE': 'queue_name'})
+    @patch.dict(os.environ, {"TARGET_QUEUE": "queue_name"})
     def test_get_target_queue(self):
         queue = _get_target_queue()
-        self.assertEqual(queue, 'queue_name')
+        self.assertEqual(queue, "queue_name")
 
     def test_is_from_queue_true(self):
         event = {
-            'from_queue': 'True'
+            "from_queue": "True"
         }
         from_queue = _is_from_queue(event)
         self.assertEqual(from_queue, True)
 
     def test_is_from_queue_false(self):
         event = {
-            'from_queue': 'False'
+            "from_queue": "False"
         }
         from_queue = _is_from_queue(event)
         self.assertEqual(from_queue, False)
+
+
+class JenkinsApiTestCase(TestCase):
+    """
+    Test methods associated with querying Jenkins
+    to verify platform jobs have been triggered.
+    """
+    def test_get_jobs_list_master(self):
+        repository = "edx-platform"
+        target = "master"
+        jobs_list_pr = _get_jobs_list(repository, target)
+        self.assertEqual(
+            jobs_list_pr, JOBS_DICT["EDX_PLATFORM_PR"]
+        )
+
+    def test_get_jobs_list_master_private(self):
+        repository = "edx-platform-private"
+        target = "master"
+        jobs_list_pr = _get_jobs_list(repository, target)
+        self.assertEqual(
+            jobs_list_pr, JOBS_DICT["EDX_PLATFORM_PRIVATE_PR"]
+        )
+
+    def test_get_jobs_list_ficus(self):
+        repository = "edx-platform"
+        target = "ficus"
+        jobs_list_pr = _get_jobs_list(repository, target)
+        self.assertEqual(
+            jobs_list_pr, JOBS_DICT["EDX_PLATFORM_FICUS_PR"]
+        )
+
+    def test_get_jobs_list_ginkgo(self):
+        repository = "edx-platform"
+        target = "ginkgo"
+        jobs_list_pr = _get_jobs_list(repository, target)
+        self.assertEqual(
+            jobs_list_pr, JOBS_DICT["EDX_PLATFORM_GINKGO_PR"]
+        )
+
+    def test_get_jobs_list_foo(self):
+        repository = "foo"
+        target = "master"
+        jobs_list_pr = _get_jobs_list(repository, target)
+        self.assertEqual(
+            jobs_list_pr, []
+        )
+
+    @patch("process_webhooks.process_webhooks._get_jobs_list",
+           return_value={})
+    def test_parse_hook_pr_master(self, _jobs_list_mock):
+        payload = pr_event.get("body")
+        payload["pull_request"]["base"]["ref"] = "refs/heads/master"
+        event_type = "pull_request"
+        sha, _ = _parse_hook_for_testing_info(payload, event_type)
+        self.assertEqual(sha, "2aebed50cfda531dd0c0d3916c084fd26d81362f")
+
+    @patch("process_webhooks.process_webhooks._get_jobs_list",
+           return_value={})
+    def test_parse_hook_pr_ficus(self, _jobs_list_mock):
+        payload = pr_event.get("body")
+        payload["pull_request"]["base"]["ref"] = \
+            "refs/heads/open-release/ficus.master"
+        event_type = "pull_request"
+        sha, _ = _parse_hook_for_testing_info(payload, event_type)
+        self.assertEqual(sha, "2aebed50cfda531dd0c0d3916c084fd26d81362f")
+
+    @patch("process_webhooks.process_webhooks._get_jobs_list",
+           return_value={})
+    def test_parse_hook_pr_ficus(self, _jobs_list_mock):
+        payload = pr_event.get("body")
+        payload["pull_request"]["base"]["ref"] = \
+            "refs/heads/open-release/ginkgo.master"
+        event_type = "pull_request"
+        sha, _ = _parse_hook_for_testing_info(payload, event_type)
+        self.assertEqual(sha, "2aebed50cfda531dd0c0d3916c084fd26d81362f")
+
+    def test_parse_hook_comment(self):
+        sha, _ = _parse_hook_for_testing_info(None, "issue_comment")
+        self.assertEqual(sha, None)
+
+    def test_parse_executable_pr_running(self):
+        data = {
+            "actions": [{
+                "parameters": [{
+                    "name": "sha1",
+                    "value": "12345"
+                }]
+            }],
+            "url": "https://build.testeng.edx.org"
+                   "/job/edx-platform-bok-choy-pr/1234"
+        }
+        build_status = "running"
+        event_type = "pull_request"
+
+        expected_response = [{
+            "job_name": "edx-platform-bok-choy-pr", "sha": "12345"
+        }]
+        actual_response = _parse_executable_for_builds(
+            data, build_status, event_type, "12345"
+        )
+        self.assertEqual(expected_response, actual_response)
+        empty_response = _parse_executable_for_builds(
+            data, build_status, event_type, ""
+        )
+        self.assertEqual(empty_response, [])
+
+    def test_parse_executable_pr_queued(self):
+        data = {
+            "actions": [{
+                "parameters": [{
+                    "name": "sha1",
+                    "value": "12345"
+                }]
+            }],
+            "task": {
+                "name": "edx-platform-bok-choy-pr"
+            }
+        }
+        build_status = "queued"
+        event_type = "pull_request"
+        expected_response = [{
+            "job_name": "edx-platform-bok-choy-pr", "sha": "12345"
+        }]
+        actual_response = _parse_executable_for_builds(
+            data, build_status, event_type, "12345"
+        )
+        self.assertEqual(expected_response, actual_response)
+        empty_response = _parse_executable_for_builds(
+            data, build_status, event_type, ""
+        )
+        self.assertEqual(empty_response, [])
+
+    @staticmethod
+    def mock_running_response():
+        data = {
+            "computer": [{
+                "executors": [{
+                    "currentExecutable": {
+                        "actions": [{
+                            "parameters": [{
+                                "name": "sha1",
+                                "value": "12345"
+                            }]
+                        }],
+                        "url": "https://build.testeng.edx.org"
+                               "/job/edx-platform-bokchoy-pr/1234"
+                        }
+                }],
+                "oneOffExecutors": []
+            }]
+        }
+        return data
+
+    @patch("process_webhooks.process_webhooks.get",
+           return_value=Response())
+    def test_get_running_builds(self, json_mock):
+        with patch(
+            "botocore.vendored.requests.models.Response.json",
+            return_value=self.mock_running_response()
+        ):
+            expected_response = [
+                {"job_name": "edx-platform-bokchoy-pr", "sha": "12345"}
+            ]
+            url = "https://www.jenkins.org"
+            username = "username"
+            token = "password"
+            actual_response = _get_running_builds(
+                url, username, token, "pull_request", "12345"
+            )
+            self.assertEqual(expected_response, actual_response)
+
+    def test_get_triggered_from_list(self):
+        jobs_list = JOBS_DICT["EDX_PLATFORM_PR"]
+        builds = [{
+            "job_name": "edx-platform-bok-choy-pr",
+            "sha": "12345"
+        }, {
+            "job_name": "edx-platform-accessibility-pr",
+            "sha": "12345"
+        }, {
+            "job_name": "edx-platform-js-pr",
+            "sha": "12345"
+        }, {
+            "job_name": "edx-platform-lettuce-pr",
+            "sha": "12345"
+        }]
+        sha = "12345"
+        already_triggered = [
+            "edx-platform-quality-pr", "edx-platform-python-unittests-pr"
+        ]
+        jobs = _get_triggered_jobs_from_list(
+            builds, already_triggered, sha, jobs_list
+        )
+        self.assertEqual(set(jobs), set(jobs_list))
+
+    def test_all_tests_triggered(self):
+        triggered_jobs = [
+            "edx-platform-quality-pr", "edx-platform-python-unittests-pr",
+            "edx-platform-bok-choy-pr", "edx-platform-accessibility-pr",
+            "edx-platform-js-pr", "edx-platform-lettuce-pr",
+        ]
+        all_triggered = _all_jobs_triggered(
+            triggered_jobs, JOBS_DICT["EDX_PLATFORM_PR"]
+        )
+        self.assertEqual(all_triggered, True)
+        triggered_jobs.pop()
+        all_triggered = _all_jobs_triggered(
+            triggered_jobs, JOBS_DICT["EDX_PLATFORM_PR"]
+        )
+        self.assertEqual(all_triggered, False)
 
 
 class ProcessWebhooksRequestTestCase(TestCase):
@@ -88,116 +387,217 @@ class ProcessWebhooksRequestTestCase(TestCase):
 
     def test_send_message_success(self):
         with patch(
-            'process_webhooks.process_webhooks.post',
+            "process_webhooks.process_webhooks.post",
             return_value=self.mock_response(200)
         ):
-            response = _send_message('http://www.example.com', None, None)
+            response = _send_message("http://www.example.com", None, None)
             self.assertIsNotNone(response)
             self.assertEqual(response.status_code, 200)
 
     def test_send_message_error(self):
         with patch(
-            'process_webhooks.process_webhooks.post',
+            "process_webhooks.process_webhooks.post",
             return_value=self.mock_response(500)
         ):
             with self.assertRaises(StandardError):
-                response = _send_message('http://www.example.com', None, None)
-                self.assertEqual(response.message, '500 Server Error: None')
+                response = _send_message("http://www.example.com", None, None)
+                self.assertEqual(response.message, "500 Server Error: None")
 
 
 class LambdaHandlerTestCase(TestCase):
-    event = {
-        'spigot_state': '',
-        'body': {
-            'zen': 'Non-blocking is better than blocking.',
-            'hook_id': 12341234,
-            'hook': {
-                'type': 'Repository',
-                'id': 98765432,
-                'events': ['issue_comment', 'pull_request']
-            },
-            'repository': {'id': 12341234, 'name': 'foo'},
-            'sender': {'id': 12345678},
-        },
-        'headers': {'X-GitHub-Event': 'ping'}
-    }
-
-    @patch('process_webhooks.process_webhooks._get_target_url',
-           return_value='http://www.example.com/endpoint/')
-    @patch('process_webhooks.process_webhooks._send_message',
+    @patch("process_webhooks.process_webhooks._get_target_url",
+           return_value="http://www.example.com")
+    @patch("process_webhooks.process_webhooks._get_url_endpoint",
+           return_value="http://www.example.com/endpoint/")
+    @patch("process_webhooks.process_webhooks._send_message",
            return_value={})
-    def test_lambda_handler_to_target(self, send_msg_mock, _url_mock):
-        self.event['spigot_state'] = 'ON'
-        lambda_handler(self.event, None)
+    @patch("process_webhooks.process_webhooks._parse_hook_for_testing_info",
+           return_value=("12345", JOBS_DICT['EDX_PLATFORM_PR']))
+    @patch("process_webhooks.process_webhooks._get_all_triggered_builds",
+           return_value={})
+    @patch("process_webhooks.process_webhooks._get_triggered_jobs_from_list",
+           return_value=list(JOBS_DICT['EDX_PLATFORM_PR']))
+    @patch("process_webhooks.process_webhooks._all_jobs_triggered",
+           return_value=True)
+    def test_lambda_handler_to_target_jobs_list(
+        self, all_triggered_mock, _from_list_mock, _get_jobs_mock,
+        _parse_hook_mock, send_msg_mock, _url_mock, _url_endpoint
+    ):
+        pr_event["spigot_state"] = "ON"
+        lambda_handler(pr_event, None)
         send_msg_mock.assert_called_with(
-            'http://www.example.com/endpoint/',
-            self.event.get('body'),
-            {'Content-Type': 'application/json', 'X-GitHub-Event': u'ping'}
+            "http://www.example.com/endpoint/",
+            pr_event.get("body"),
+            {"Content-Type": "application/json",
+             "X-GitHub-Event": u"pull_request"}
+        )
+        all_triggered_mock.assert_called_with(
+            list(JOBS_DICT['EDX_PLATFORM_PR']),
+            JOBS_DICT['EDX_PLATFORM_PR']
         )
 
-    @patch('process_webhooks.process_webhooks._get_target_url',
-           return_value='http://www.example.com/endpoint/')
-    @patch('process_webhooks.process_webhooks._send_message',
-           side_effect=StandardError("Error!"))
-    @patch('process_webhooks.process_webhooks._is_from_queue',
+    @patch("process_webhooks.process_webhooks._get_target_url",
+           return_value="http://www.example.com")
+    @patch("process_webhooks.process_webhooks._get_url_endpoint",
+           return_value="http://www.example.com/endpoint/")
+    @patch("process_webhooks.process_webhooks._send_message",
+           return_value={})
+    @patch("process_webhooks.process_webhooks._parse_hook_for_testing_info",
+           return_value=("12345", ('job1', 'job2')))
+    @patch("process_webhooks.process_webhooks._get_all_triggered_builds",
+           return_value={})
+    @patch("process_webhooks.process_webhooks._all_jobs_triggered",
+           return_value=True)
+    def test_lambda_handler_to_target_jobs_list_already_triggered(
+        self, all_triggered_mock, _get_jobs_mock,
+        _parse_hook_mock, send_msg_mock, _url_mock, _url_endpoint
+    ):
+        pr_event.update({"already_triggered": "['job1', 'job2']"})
+        pr_event["spigot_state"] = "ON"
+        lambda_handler(pr_event, None)
+        send_msg_mock.assert_called_with(
+            "http://www.example.com/endpoint/",
+            pr_event.get("body"),
+            {"Content-Type": "application/json",
+             "X-GitHub-Event": u"pull_request"}
+        )
+        all_triggered_mock.assert_called_with(
+            ['job1', 'job2'],
+            ('job1', 'job2')
+        )
+        pr_event.pop('already_triggered')
+
+    @patch("process_webhooks.process_webhooks._get_target_url",
+           return_value="http://www.example.com")
+    @patch("process_webhooks.process_webhooks._get_url_endpoint",
+           return_value="http://www.example.com/endpoint/")
+    @patch("process_webhooks.process_webhooks._send_message",
+           return_value={})
+    @patch("process_webhooks.process_webhooks._parse_hook_for_testing_info",
+           return_value=("12345", JOBS_DICT['EDX_PLATFORM_PR']))
+    @patch("process_webhooks.process_webhooks._get_all_triggered_builds",
+           return_value={})
+    @patch("process_webhooks.process_webhooks._get_triggered_jobs_from_list",
+           return_value=[])
+    @patch("process_webhooks.process_webhooks._all_jobs_triggered",
            return_value=False)
-    @patch('process_webhooks.process_webhooks._get_target_queue',
-           return_value='queue_name')
-    @patch('process_webhooks.process_webhooks._send_to_queue',
+    @patch("process_webhooks.process_webhooks._get_target_queue",
+           return_value="queue_name")
+    @patch("process_webhooks.process_webhooks._send_to_queue",
+           return_value=None)
+    def test_lambda_handler_to_target_jobs_list_not_triggered(
+        self, send_to_queue, _queue_mock, all_triggered_mock,
+        _from_list_mock, _get_jobs_mock, _parse_hook_mock,
+        send_msg_mock, _url_mock, _url_endpoint
+    ):
+        pr_event["spigot_state"] = "ON"
+        with self.assertRaises(StandardError):
+            lambda_handler(pr_event, None)
+        send_msg_mock.assert_called_with(
+            "http://www.example.com/endpoint/",
+            pr_event.get("body"),
+            {"Content-Type": "application/json",
+             "X-GitHub-Event": u"pull_request"}
+        )
+        all_triggered_mock.assert_called_with(
+            [],
+            JOBS_DICT['EDX_PLATFORM_PR']
+        )
+        send_to_queue.assert_called_with(pr_event, "queue_name")
+        pr_event.pop('already_triggered')
+
+    @patch("process_webhooks.process_webhooks._get_target_url",
+           return_value="http://www.example.com")
+    @patch("process_webhooks.process_webhooks._get_url_endpoint",
+           return_value="http://www.example.com/endpoint/")
+    @patch("process_webhooks.process_webhooks._send_message",
+           return_value={})
+    @patch("process_webhooks.process_webhooks._parse_hook_for_testing_info",
+           return_value=(None, []))
+    def test_lambda_handler_to_target_no_jobs_list(
+        self, _parse_hook_mock, send_msg_mock,
+        _url_mock, _url_endpoint
+    ):
+        pr_event["spigot_state"] = "ON"
+        lambda_handler(pr_event, None)
+        send_msg_mock.assert_called_with(
+            "http://www.example.com/endpoint/",
+            pr_event.get("body"),
+            {"Content-Type": "application/json",
+             "X-GitHub-Event": u"pull_request"}
+        )
+
+    @patch("process_webhooks.process_webhooks._get_target_url",
+           return_value="http://www.example.com")
+    @patch("process_webhooks.process_webhooks._get_url_endpoint",
+           return_value="http://www.example.com/endpoint/")
+    @patch("process_webhooks.process_webhooks._send_message",
+           side_effect=StandardError("Error!"))
+    @patch("process_webhooks.process_webhooks._is_from_queue",
+           return_value=False)
+    @patch("process_webhooks.process_webhooks._get_target_queue",
+           return_value="queue_name")
+    @patch("process_webhooks.process_webhooks._send_to_queue",
            return_value={})
     def test_lambda_handler_to_target_error(
         self, send_queue_mock, _queue_mock,
-        _from_queue_mock, send_msg_mock, _url_mock
+        _from_queue_mock, send_msg_mock,
+        _url_mock, _url_endpoint
     ):
-        self.event['spigot_state'] = 'ON'
+        pr_event["spigot_state"] = "ON"
         with self.assertRaises(StandardError):
-            lambda_handler(self.event, None)
-
+            lambda_handler(pr_event, None)
         send_msg_mock.assert_called_with(
-            'http://www.example.com/endpoint/',
-            self.event.get('body'),
-            {'Content-Type': 'application/json', 'X-GitHub-Event': u'ping'}
+            "http://www.example.com/endpoint/",
+            pr_event.get("body"),
+            {"Content-Type": "application/json",
+             "X-GitHub-Event": u"pull_request"}
         )
         send_queue_mock.assert_called_with(
-            self.event,
-            'queue_name'
+            pr_event,
+            "queue_name"
         )
 
-    @patch('process_webhooks.process_webhooks._get_target_url',
+    @patch("process_webhooks.process_webhooks._get_target_url",
            return_value=None)
-    @patch('process_webhooks.process_webhooks._send_message',
+    @patch("process_webhooks.process_webhooks._get_url_endpoint",
+           return_value=None)
+    @patch("process_webhooks.process_webhooks._send_message",
            return_value={})
-    def test_lambda_handler_ping(self, send_msg_mock, _url_mock):
-        self.event['spigot_state'] = 'ON'
-        lambda_handler(self.event, None)
+    def test_lambda_handler_ping(
+        self, send_msg_mock,
+        _url_mock, _url_endpoint
+    ):
+        ping_event["spigot_state"] = "ON"
+        lambda_handler(ping_event, None)
         assert not send_msg_mock.called
 
-    @patch('process_webhooks.process_webhooks._get_target_queue',
-           return_value='queue_name')
-    @patch('process_webhooks.process_webhooks._is_from_queue',
+    @patch("process_webhooks.process_webhooks._get_target_queue",
+           return_value="queue_name")
+    @patch("process_webhooks.process_webhooks._is_from_queue",
            return_value=False)
-    @patch('process_webhooks.process_webhooks._send_to_queue',
+    @patch("process_webhooks.process_webhooks._send_to_queue",
            return_value={})
     def test_lambda_handler_to_queue(
         self, send_queue_mock, _from_queue_mock, _queue_mock
     ):
-        self.event['spigot_state'] = 'OFF'
-        lambda_handler(self.event, None)
+        pr_event["spigot_state"] = "OFF"
+        lambda_handler(pr_event, None)
         send_queue_mock.assert_called_with(
-            self.event,
-            'queue_name'
+            pr_event,
+            "queue_name"
         )
 
-    @patch('process_webhooks.process_webhooks._get_target_queue',
-           return_value='queue_name')
-    @patch('process_webhooks.process_webhooks._is_from_queue',
+    @patch("process_webhooks.process_webhooks._get_target_queue",
+           return_value="queue_name")
+    @patch("process_webhooks.process_webhooks._is_from_queue",
            return_value=True)
-    @patch('process_webhooks.process_webhooks._send_to_queue',
+    @patch("process_webhooks.process_webhooks._send_to_queue",
            return_value={})
     def test_lambda_handler_to_queue_from_queue(
         self, send_queue_mock, _from_queue_mock, _queue_mock
     ):
-        self.event['spigot_state'] = 'OFF'
+        pr_event["spigot_state"] = "OFF"
         with self.assertRaises(StandardError):
-            lambda_handler(self.event, None)
+            lambda_handler(pr_event, None)
         assert not send_queue_mock.called

--- a/lambdas/send_from_queue/send_from_queue.py
+++ b/lambdas/send_from_queue/send_from_queue.py
@@ -181,7 +181,7 @@ def lambda_handler(event, _context):
     # Rather than hardcoding the api url, get it from boto.
     # Add the query param so the process_webhooks lambda
     # knows the webhook is coming from the queue.
-    api_url_query = _get_api_url() + "?from_queue=True"
+    api_url = _get_api_url() + "?from_queue=True"
 
     # The SQS queue is draining
     logger.info('Attempting to drain the queue.')
@@ -208,18 +208,41 @@ def lambda_handler(event, _context):
                     "queue. {}".format(message_body)
                 )
 
+            api_url_full_query = api_url
+            already_triggered = message_body.get("already_triggered")
+            if already_triggered:
+                    api_url_full_query = api_url_full_query + \
+                        "&already_triggered={}".format(already_triggered)
+
             # Send the SQS message to the API Gateway
             response = post(
-                api_url_query,
+                api_url_full_query,
                 json=payload,
                 headers=headers,
                 timeout=(3.05, 30)
             )
 
-            # If there was a problem, raise an error
-            response.raise_for_status()
+            error_message = "More jobs triggered, but " \
+                            "unable to trigger all jobs."
+            if error_message in response.text:
+                # The hook failed to trigger all jobs, so
+                # process_webhooks has returned an error.
+                # However this hook has been replaced in the queue
+                # so we should delete this obsolete hook now,
+                # before raising an error.
+                _delete_from_queue(queue_object, message)
 
-            # Otherwise, delete the message since it has been processed
+            try:
+                # If there was a problem, raise an error
+                response.raise_for_status()
+            except:
+                raise StandardError(
+                    "Unable to clear item from the queue due to "
+                    "an error from process_webhooks."
+                )
+
+            # If no error was returned, delete the message since it has
+            # successfully been processed.
             _delete_from_queue(queue_object, message)
 
     # If this gets reached before a timeout, the queue had been emptied

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ coverage==3.7.1
 ddt==0.8.0
 nose==1.3.4
 pep8==1.5.7
-edx-lint==0.4.3
+edx-lint==0.5.4
 mock==1.0.1
 moto==0.4.2
 testfixtures==4.1.2

--- a/travis/build_info.py
+++ b/travis/build_info.py
@@ -9,10 +9,9 @@ from __future__ import division
 
 import argparse
 import logging
-import requests
 import sys
-
 from operator import itemgetter
+import requests
 
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -87,8 +86,8 @@ def get_last_n_successful_builds(org, repo, number):
     # if we can't get the specified number of builds, just return everything
     if len(successful_builds) < number:
         return successful_builds
-    else:
-        return successful_builds[:number]
+
+    return successful_builds[:number]
 
 
 def get_average_build_duration(builds):

--- a/travis/tests/test_build_info.py
+++ b/travis/tests/test_build_info.py
@@ -1,13 +1,13 @@
 """
 Tests for testeng-ci/travis/build_info
 """
+from unittest import TestCase
+import os
 from ddt import ddt, data
 from mock import patch
 from testfixtures import LogCapture
-from unittest import TestCase
 
 import httpretty
-import os
 import requests
 
 from travis.build_info import (


### PR DESCRIPTION
Overview
---
The proposed PR allows the Spigot to query the Jenkins REST API to ensure that all expected jobs are triggered by platform pull_request hooks.

- When the Spigot identifies a pull_request hook on platform, it queries the Jenkins API and finds all running or queued builds matching that sha. Based on that hooks target (master/ficus/ginkgo/etc), it is able to identify whether or not all the expected jobs have been triggered.
- If all the jobs have been triggered, Github receives a 200 and no further action is required.
- If some jobs are missing, the hook is sent to the SQS queue for future processing. Inside the hook, the Spigot stores all of the jobs that were successfully triggered. This prevents us from having to worry about jobs like js or quality (which are much shorter than others) finishing before we've verified other jobs have been kicked off.
- When send_from_queue resends a hook to process_webhooks, it includes a new query string parameter (in addition to from_queue) called already_triggered, which is the list of these jobs. If no new jobs are triggered, nothing happens and the message stays in the queue. However, if more jobs are updated (but not all), then the message is deleted and replaced with a new message that is aware of the updated list of triggered jobs.
- Credentials for the query are stored in S3. This allows us to query for private jobs.