### PR TITLE
Action parameters placement in the dict is not deterministic in Jenkins 2.0

### DIFF
--- a/.pep8
+++ b/.pep8
@@ -1,0 +1,2 @@
+[pep8]
+max_line_length=119

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,14 @@ branches:
       - master
 python:
   - "2.7"
-env:
-  - PACKAGES_STRING="jenkins,aws,release,mobile_app,travis,lambdas"
 install:
   - pip install -r test-requirements.txt
 script:
   - pep8 .
   - pylint travis/
-  - nosetests -v --with-coverage --cover-package=$PACKAGES_STRING
+  - pytest --cov-report term-missing --cov=jenkins jenkins
+  - pytest --cov-report term-missing --cov=aws aws
+  - pytest --cov-report term-missing --cov=release release
+  - pytest --cov-report term-missing --cov=mobile_app mobile_app
+  - pytest --cov-report term-missing --cov=travis travis
+  - pytest --cov-report term-missing --cov=lambdas lambdas

--- a/jenkins/build.py
+++ b/jenkins/build.py
@@ -19,21 +19,24 @@ class Build(dict):
 
         author = None
         pr_id = None
-        actions = build.get('actions')
-        if actions:
-            action_parameters = actions[0].get('parameters')
-            if action_parameters:
-                for p in action_parameters:
-                    if p.get('name') == u'ghprbActualCommitAuthorEmail':
-                        author = p.get('value')
-                    if p.get('name') == u'ghprbPullId':
-                        pr_id = p.get('value')
-            else:
-                logger.debug(
-                    "Couldn't find build parameters for build #{}".format(
-                        build.get('number')
+        actions = build.get('actions', [])
+        ghprb_class_name = u'org.jenkinsci.plugins.ghprb.GhprbParametersAction'
+
+        for action in actions:
+            if action.get('_class') == ghprb_class_name:
+                action_parameters = action.get('parameters')
+                if action_parameters:
+                    for p in action_parameters:
+                        if p.get('name') == u'ghprbActualCommitAuthorEmail':
+                            author = p.get('value')
+                        if p.get('name') == u'ghprbPullId':
+                            pr_id = p.get('value')
+                else:
+                    logger.debug(
+                        "Couldn't find build parameters for build #{}".format(
+                            build.get('number')
+                        )
                     )
-                )
 
         self.author = author
         self.pr_id = pr_id

--- a/jenkins/tests/helpers.py
+++ b/jenkins/tests/helpers.py
@@ -75,35 +75,44 @@ def sample_data(running_builds, not_running_builds):
     def mktimestamp(minutes_ago):
         first_time = 142009200 * 1000
         build_time = first_time - (minutes_ago * 60000)
-        return str(build_time)
+        return build_time
 
     for i in range(0, len(running_builds)):
-        builds.append(
-            '{"actions" : [{"parameters" :[{"name": "ghprbPullId",'
-            '"value" : "' +
-            running_builds[i].get(
-                'prnum') + '"}, {"name":"ghprbActualCommitAuthorEmail",'
-            '"value":"' + running_builds[i].get('author') + '"}]},{},{}], '
-            '"building": true, "number": ' + str(i) +
-            ', "timestamp" : ' + mktimestamp(i) + '}'
-        )
+        parameters = [
+            {'name': 'ghprbPullId', 'value': running_builds[i].get('prnum')},
+            {'name': 'ghprbActualCommitAuthorEmail', 'value': running_builds[i].get('author')}
+        ]
+        actions = [
+            {
+                '_class': 'org.jenkinsci.plugins.ghprb.GhprbParametersAction',
+                'parameters': parameters
+            }, {}, {}
+        ]
+        builds.append({
+            'actions': actions,
+            'building': True,
+            'number': i,
+            'timestamp': mktimestamp(i)
+        })
 
     for i in range(0, len(not_running_builds)):
         num = i + len(running_builds)
-        builds.append(
-            '{"actions" : [{"parameters" :[{"name": "ghprbPullId",'
-            '"value" : "' +
-            not_running_builds[i].get(
-                'prnum') + '"}, {"name":"ghprbActualCommitAuthorEmail",'
-            '"value":"' + not_running_builds[i].get('author') + '"}]},{},{}], '
-            '"building": false, "number": ' + str(num) +
-            ', "timestamp" : ' + mktimestamp(num) + '}'
-        )
+        parameters = [
+            {'name': 'ghprbPullId', 'value': not_running_builds[i].get('prnum')},
+            {'name': 'ghprbActualCommitAuthorEmail', 'value': not_running_builds[i].get('author')}
+        ]
+        actions = [
+            {
+                '_class': 'org.jenkinsci.plugins.ghprb.GhprbParametersAction',
+                'parameters': parameters
+            }, {}, {}
+        ]
+        builds.append({
+            'actions': actions,
+            'building': False,
+            'number': num,
+            'timestamp': mktimestamp(num)
+        })
 
-    build_data = ''.join([
-        '{"builds": [',
-        ','.join(builds),
-        ']}',
-    ])
-
-    return json.loads(build_data)
+    build_data = {'builds': builds}
+    return build_data

--- a/jenkins/tests/test_timeout.py
+++ b/jenkins/tests/test_timeout.py
@@ -56,9 +56,9 @@ class TimeoutTestCase(TestCase):
     def test_stop_stuck_builds_with_stuck(self, mock_desc,
                                           update_desc,
                                           stop_build):
-        sample_buid_data = sample_data(
+        sample_build_data = sample_data(
             [Pr('0').dict, Pr('1').dict, Pr('2').dict, Pr('3').dict], [])
-        build_data = self.timer.get_stuck_builds(sample_buid_data)
+        build_data = self.timer.get_stuck_builds(sample_build_data)
         self.timer.stop_stuck_builds(build_data)
 
         stop_build.assert_has_calls([call(3), call(2)], any_order=True)
@@ -72,9 +72,9 @@ class TimeoutTestCase(TestCase):
     @patch('jenkins.job.JenkinsJob.stop_build', side_effect=HTTPError())
     @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
     def test_stop_stuck_builds_failed_to_stop(self, update_desc, stop_build):
-        sample_buid_data = sample_data(
+        sample_build_data = sample_data(
             [Pr('1').dict, Pr('2').dict, Pr('3').dict], [])
-        build_data = self.timer.get_stuck_builds(sample_buid_data)
+        build_data = self.timer.get_stuck_builds(sample_build_data)
         self.timer.stop_stuck_builds(build_data)
         stop_build.assert_called_once_with(2)
         self.assertFalse(update_desc.called)
@@ -83,9 +83,9 @@ class TimeoutTestCase(TestCase):
     @patch('jenkins.job.JenkinsJob.stop_build', return_value=True)
     @patch('jenkins.job.JenkinsJob.update_build_desc', return_value=True)
     def test_stop_stuck_builds_none_stuck(self, update_desc, stop_build):
-        sample_buid_data = sample_data(
+        sample_build_data = sample_data(
             [Pr('1').dict, Pr('2').dict], [Pr('2').dict])
-        build_data = self.timer.get_stuck_builds(sample_buid_data)
+        build_data = self.timer.get_stuck_builds(sample_build_data)
         self.timer.stop_stuck_builds(build_data)
         self.assertFalse(stop_build.called)
         self.assertFalse(update_desc.called)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,9 +3,10 @@
 
 coverage==3.7.1
 ddt==0.8.0
-nose==1.3.4
-pep8==1.5.7
 edx-lint==0.5.4
 mock==1.0.1
 moto==0.4.2
+pep8==1.5.7
+pytest==3.2.3
+pytest-cov==2.5.1
 testfixtures==4.1.2


### PR DESCRIPTION
or at least they're no longer in the first element of the array.

Also:
* switching from nose to pytest
* relaxing pep8 to allow longer lines