### PR TITLE
Estute/pass env vars to subset workers

### DIFF
--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -6,12 +6,25 @@ def sha1 = build.environment.get("ghprbActualCommit")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
 def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
+def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+
+// Any environment variables that you want to inject into the environment of
+// child jobs of this build flow should be added here (comma-separated,
+// in the format VARIABLE=VALUE)
+def envVarString = "DJANGO_VERSION=${djangoVersion}"
 
 guard{
     parallel(
       (1..11).collect { index ->
         return {
-          bokchoybuild = build(subsetJob, sha1: sha1, SHARD: index, TEST_SUITE: "bok-choy", PARENT_BUILD: "master #" + build.number, WORKER_LABEL: workerLabel)
+          bokchoybuild = build(subsetJob,
+                               sha1: sha1,
+                               SHARD: index,
+                               TEST_SUITE: "bok-choy",
+                               PARENT_BUILD: "master #" + build.number,
+                               WORKER_LABEL: workerLabel,
+                               ENV_VARS: envVarString
+                               )
           toolbox.slurpArtifacts(bokchoybuild)
 
           }

--- a/jenkins/flow/pr/edx-platform-lettuce-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-lettuce-pr.groovy
@@ -6,15 +6,35 @@ def sha1 = build.environment.get("ghprbActualCommit")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
 def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
+def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+
+// Any environment variables that you want to inject into the environment of
+// child jobs of this build flow should be added here (comma-separated,
+// in the format VARIABLE=VALUE)
+def envVarString = "DJANGO_VERSION=${djangoVersion}"
 
 guard{
   parallel(
     {
-      lettuce_lms = build(subsetJob, sha1: sha1, SHARD: "all", TEST_SUITE: "lms-acceptance", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+      lettuce_lms = build(subsetJob,
+                          sha1: sha1,
+                          SHARD: "all",
+                          TEST_SUITE: "lms-acceptance",
+                          PARENT_BUILD: "PR Build #" + build.number,
+                          WORKER_LABEL: workerLabel,
+                          ENV_VARS: envVarString
+                          )
       toolbox.slurpArtifacts(lettuce_lms)
     },
     {
-      lettuce_cms = build(subsetJob, sha1: sha1, SHARD: "all", TEST_SUITE: "cms-acceptance", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+      lettuce_cms = build(subsetJob,
+                          sha1: sha1,
+                          SHARD: "all",
+                          TEST_SUITE: "cms-acceptance",
+                          PARENT_BUILD: "PR Build #" + build.number,
+                          WORKER_LABEL: workerLabel,
+                          ENV_VARS: envVarString
+                          )
       toolbox.slurpArtifacts(lettuce_cms)
     },
   )

--- a/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
@@ -8,31 +8,79 @@ def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset
 def repoName = build.environment.get("REPO_NAME") ?: "edx-platform"
 def coverageJob = build.environment.get("COVERAGE_JOB") ?: "edx-platform-unit-coverage"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
+def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+
+// Any environment variables that you want to inject into the environment of
+// child jobs of this build flow should be added here (comma-separated,
+// in the format VARIABLE=VALUE)
+def envVarString = "DJANGO_VERSION=${djangoVersion}"
 
 guard{
     unit = parallel(
       {
-        lms_unit_1 = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "lms-unit", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+        lms_unit_1 = build(subsetJob,
+                           sha1: sha1,
+                           SHARD: "1",
+                           TEST_SUITE: "lms-unit",
+                           PARENT_BUILD: "PR Build #" + build.number,
+                           WORKER_LABEL: workerLabel,
+                           ENV_VARS: envVarString
+                           )
         toolbox.slurpArtifacts(lms_unit_1)
       },
       {
-        lms_unit_2 = build(subsetJob, sha1: sha1, SHARD: "2", TEST_SUITE: "lms-unit", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+        lms_unit_2 = build(subsetJob,
+                           sha1: sha1, 
+                           SHARD: "2", 
+                           TEST_SUITE: "lms-unit",
+                           PARENT_BUILD: "PR Build #" + build.number,
+                           WORKER_LABEL: workerLabel, 
+                           ENV_VARS: envVarString
+                           )
         toolbox.slurpArtifacts(lms_unit_2)
       },
       {
-        lms_unit_3 = build(subsetJob, sha1: sha1, SHARD: "3", TEST_SUITE: "lms-unit", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+        lms_unit_3 = build(subsetJob, 
+                           sha1: sha1,
+                           SHARD: "3", 
+                           TEST_SUITE: "lms-unit",
+                           PARENT_BUILD: "PR Build #" + build.number,
+                           WORKER_LABEL: workerLabel,
+                           ENV_VARS: envVarString
+                           )
         toolbox.slurpArtifacts(lms_unit_3)
       },
       {
-        lms_unit_4 = build(subsetJob, sha1: sha1, SHARD: "4", TEST_SUITE: "lms-unit", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+        lms_unit_4 = build(subsetJob,
+                           sha1: sha1,
+                           SHARD: "4",
+                           TEST_SUITE: "lms-unit",
+                           PARENT_BUILD: "PR Build #" + build.number,
+                           WORKER_LABEL: workerLabel,
+                           ENV_VARS: envVarString
+                           )
         toolbox.slurpArtifacts(lms_unit_4)
       },
       {
-        cms_unit = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "cms-unit", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+        cms_unit = build(subsetJob,
+                         sha1: sha1,
+                         SHARD: "1",
+                         TEST_SUITE: "cms-unit",
+                         PARENT_BUILD: "PR Build #" + build.number,
+                         WORKER_LABEL: workerLabel,
+                         ENV_VARS: envVarString
+                         )
         toolbox.slurpArtifacts(cms_unit)
       },
       {
-        commonlib_unit = build(subsetJob, sha1: sha1, SHARD: "1", TEST_SUITE: "commonlib-unit", PARENT_BUILD: "PR Build #" + build.number, WORKER_LABEL: workerLabel)
+        commonlib_unit = build(subsetJob,
+                               sha1: sha1,
+                               SHARD: "1", 
+                               TEST_SUITE: "commonlib-unit",
+                               PARENT_BUILD: "PR Build #" + build.number,
+                               WORKER_LABEL: workerLabel, 
+                               ENV_VARS: envVarString
+                               )
         toolbox.slurpArtifacts(commonlib_unit)
       },
     )


### PR DESCRIPTION
This will allow us to pass arbitrary environment variables to the edx-platform-test-subset job (which is used by all of the flow jobs). I am planning on using this to get subset jobs to run django 1.8 (default) or django 1.11 (when specified) without needing to create a separate subset job.

NOTE: this is only for pr jobs. 