### PR TITLE
clean up python artifacts

### DIFF
--- a/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
@@ -64,4 +64,21 @@ guard{
     FilePath artifactsDir =  new FilePath(build.artifactManager.getArtifactsDir())
     FilePath copyToDir = new FilePath(build.workspace, repoName)
     artifactsDir.copyRecursiveTo(copyToDir)
+
+    // Delete the report artifacts that we copied into the staging area, to reduce
+    // disk usage. These are copied by the HTML Publisher plugin and the
+    // Shining Panda Coverage plugin, and these are redundant. However, leave
+    // the 'test_root' directory, as it is indexed by Splunk for paver timing
+    // reports
+    List toDelete = artifactsDir.list().findAll { item ->
+        item.getName() != 'test_root' 
+    }
+    toDelete.each { item ->
+        if (item.isDirectory()) {
+            item.deleteRecursive()
+        } else {
+            item.delete()
+        }
+    }
+
 }


### PR DESCRIPTION
Recently python build sizes have increased a lot. In an effort to stop python builds from filling up Jenkins data olume, I have put in a fix to how we call pytest(see:  https://github.com/edx/edx-platform/pull/16401). 

Additionally, I realized that we were storing duplicate versions of report data. The build flow scripts were copying build artifacts from the subet job shards back into the artifacts directory of the build flow job itself (as a staging area) and then copying them into the workspace. The rationale for this is so that both the HTML publisher plugin and shining panda coverage plugin can access the report artifacts once they are in the workspace. This PR simply cleans up the report artifacts in the artifacts directory of the build flow job. Both aforementioned plugins store their own copy of the report artifacts and therefore shouldn't be affected by this.

I have tested this on my sandbox using a version of the python unittests pr job, modified to use this branch of testeng-ci and be able to be triggered without a GHPRB event

Examples:
Build without deleting the report artifacts
* Link: https://test-jenkins.testeng.edx.org/job/hacking-python-job/19/
* Disk Usage:
```bash
du --human-readable --max-depth=1 hacking-python-job/builds/19
237M	hacking-python-job/builds/19/archive
129M	hacking-python-job/builds/19/coveragepy
237M	hacking-python-job/builds/19/htmlreports
699M	hacking-python-job/builds/19
```

Build with deleting the report artifacts
* Link: https://test-jenkins.testeng.edx.org/job/hacking-python-job/24/
* Disk Usage:
```bash
du --human-readable --max-depth=1 hacking-python-job/builds/24
716K	hacking-python-job/builds/24/archive
129M	hacking-python-job/builds/24/coveragepy
238M	hacking-python-job/builds/24/htmlreports
466M	hacking-python-job/builds/24
```

Note: The only noticeable difference will be the inability to download/view the individual files of the report artifacts (example: https://test-jenkins.testeng.edx.org/job/hacking-python-job/19/artifact/reports/)