### PR TITLE
Fix log statement when branch exists for db cache uploader

### DIFF
--- a/jenkins/bokchoy_db_pull_request.py
+++ b/jenkins/bokchoy_db_pull_request.py
@@ -233,7 +233,7 @@ def main(sha, repo_root):
         # for this fingerprint. To avoid excessive PR's, exit.
         logger.info(
             "Branch name: {} already exists. Exiting."
-        )
+        ).format(branch_name)
         return
 
     branch_object = _create_branch(repository, branch_name, sha)


### PR DESCRIPTION
Should include the branch name when logging that a branch exists.