### PR TITLE
add env var to not run coverage on django jobs

### DIFF
--- a/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
@@ -10,11 +10,12 @@ def coverageJob = build.environment.get("COVERAGE_JOB") ?: "edx-platform-unit-co
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
 def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
 def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
+def runCoverage = build.environment.get("RUN_COVERAGE") ?: "true"
 
 // Any environment variables that you want to inject into the environment of
 // child jobs of this build flow should be added here (comma-separated,
 // in the format VARIABLE=VALUE)
-def envVarString = "DJANGO_VERSION=${djangoVersion}"
+def envVarString = "DJANGO_VERSION=${djangoVersion}, RUN_COVERAGE=${runCoverage}"
 
 guard{
     unit = parallel(
@@ -92,7 +93,9 @@ guard{
       lms_unit_3.result.toString() == 'SUCCESS' &&
       lms_unit_4.result.toString() == 'SUCCESS' &&
       cms_unit.result.toString() == 'SUCCESS' &&
-      commonlib_unit.result.toString() == 'SUCCESS')
+      commonlib_unit.result.toString() == 'SUCCESS' &&
+      runCoverage.toBoolean()
+    )
 
     if (check_coverage){
       unit_coverage = build(coverageJob,


### PR DESCRIPTION
[TE-2385]
This pull request is part of a multi-pr change to disable both running unit tests through coverage and the coverage job for the django 1.11 upgrade work.

This pull request passes an environment variable for whether or not we should run coverage to the shards running the unit tests (see: 
https://github.com/edx/edx-platform/pull/17208) , and also conditionally calls the coverage job afterwards.

