### PR TITLE
temp fail old quality builds

### DIFF
--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -10,6 +10,15 @@ def qualityDiffJob = build.environment.get("QUALITY_DIFF_JOB") ?: "edx-platform-
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
 def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
 
+// Temporary fix until all edx-platform pull requests have rebased from master
+// to get the fix in https://github.com/edx/edx-platform/pull/17252
+File thresholdFile = new File('edx-platform/scripts/thresholds.sh')
+if(!thresholdFile.exists()) {
+    println('The quality job has been refactored and requires a fix in the platform')
+    println('Please rebase your pr and rerun this test')
+    return 1
+}
+
 guard{
     quality = parallel(
         {

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -14,9 +14,9 @@ def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
 // to get the fix in https://github.com/edx/edx-platform/pull/17252
 File thresholdFile = new File('edx-platform/scripts/thresholds.sh')
 if(!thresholdFile.exists()) {
-    println('The quality job has been refactored and requires a fix in the platform')
-    println('Please rebase your pr and rerun this test')
-    return 1
+    String failMsg = 'The quality job has been refactored and requires a fix ' +
+                     'in the platform. Please rebase your pr and rerun this test'
+    throw new Exception("${job.fullDisplayName} aborted: ${failMsg}")
 }
 
 guard{

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -13,7 +13,7 @@ def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
 // Temporary fix until all edx-platform pull requests have rebased from master
 // to get the fix in https://github.com/edx/edx-platform/pull/17252
 FilePath thresholdFilePath = new FilePath(build.workspace, 'scripts/thresholds.sh')
-File thresholdFile = new File(thresholdFilePath)
+File thresholdFile = new File(thresholdFilePath.toString())
 if(!thresholdFile.exists()) {
     String failMsg = 'The quality job has been refactored and requires a fix ' +
                      'in the platform. Please rebase your pr and rerun this test'

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -12,7 +12,8 @@ def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
 
 // Temporary fix until all edx-platform pull requests have rebased from master
 // to get the fix in https://github.com/edx/edx-platform/pull/17252
-File thresholdFile = new File('scripts/thresholds.sh')
+FilePath thresholdFilePath = new FilePath(build.workspace, 'scripts/thresholds.sh')
+File thresholdFile = new File(thresholdFilePath)
 if(!thresholdFile.exists()) {
     String failMsg = 'The quality job has been refactored and requires a fix ' +
                      'in the platform. Please rebase your pr and rerun this test'

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -12,7 +12,7 @@ def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
 
 // Temporary fix until all edx-platform pull requests have rebased from master
 // to get the fix in https://github.com/edx/edx-platform/pull/17252
-File thresholdFile = new File('edx-platform/scripts/thresholds.sh')
+File thresholdFile = new File('scripts/thresholds.sh')
 if(!thresholdFile.exists()) {
     String failMsg = 'The quality job has been refactored and requires a fix ' +
                      'in the platform. Please rebase your pr and rerun this test'

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -16,7 +16,7 @@ File thresholdFile = new File('scripts/thresholds.sh')
 if(!thresholdFile.exists()) {
     String failMsg = 'The quality job has been refactored and requires a fix ' +
                      'in the platform. Please rebase your pr and rerun this test'
-    throw new Exception("${job.fullDisplayName} aborted: ${failMsg}")
+    throw new Exception("Build aborted: ${failMsg}")
 }
 
 guard{


### PR DESCRIPTION
This is a temporary fix while we roll out the new sharded quality pr job. To make sure that people with existing pull requests that do not yet contain the fix in https://github.com/edx/edx-platform/pull/17252 do not pass quality without actually running anything, this will fail fast on the quality flow job, alerting them that they need to rebase