### PR TITLE
Add a generic EdxStatusBot class that can ignore PRs (and more).

### DIFF
--- a/jenkins/edx-platform-test-notifier.py
+++ b/jenkins/edx-platform-test-notifier.py
@@ -16,11 +16,86 @@ def _get_github_token():
     """
     token = os.environ.get('GITHUB_TOKEN')
     if not token:
-        logger.error(
-            "No value found for environment variable GITHUB_TOKEN"
-        )
+        logger.error("No value found for environment variable GITHUB_TOKEN")
         sys.exit(1)
     return token
+
+
+class EdxStatusBot:
+    """
+    A status bot that can perform multiple actions on PRs.
+    
+    Looks for lines of the form '{botname}: {action}' in a PR's body to
+    determine what actions to take.
+    """
+
+    DEFAULT_BOT_NAME = 'edx-status-bot'
+
+    # An ordered list of actions that this bot can take.
+    #
+    # Each action should correspond to a method name, and each
+    # action should have a corresponding `action`_marker method,
+    # e.g. 'ignore_marker', which tells whether the action should
+    # be taken.
+    ACTIONS = ('ignore', 'notify_tests_completed',)
+
+    def __init__(self, token, name=DEFAULT_BOT_NAME):
+        self.name = name
+        self.token = token
+        self.github = Github(self.token)
+
+    def act_on(self, pr):
+        for action in self.ACTIONS:
+            take_action = getattr(self, action + '_marker')
+            if take_action(pr):
+                getattr(self, action)(pr)
+
+    def ignore(self, pr):
+        """Ignore taking any further actions on this PR."""
+        logger.info(
+            "PR #{} author doesn't want status updates.".format(pr.number)
+        )
+        sys.exit()
+
+    def ignore_marker(self, pr):
+        return self._action_str('ignore') in pr.body
+
+    def notify_tests_completed(self, pr):
+        """Post a notification on the PR that tests have finished running."""
+        comment = "Your PR has finished running tests."
+        try:
+            pr.create_issue_comment(comment)
+        except:
+            logger.error("Failed to add issue comment to PR.")
+            sys.exit(1)
+        else:
+            logger.info("Successfully commented on PR.")
+
+    def notify_tests_completed_marker(self, pr):
+        head_commit = pr.get_commits().reversed[0]
+        for status in head_commit.get_combined_status().statuses:
+            if status.state == 'pending':
+                logger.info(
+                    "Other tests are still pending on this PR. Exiting"
+                )
+                break
+        else:
+            return True
+
+    def get_repo(self, target_repo):
+        repos = self.github.get_user().get_repos()
+        for repo in repos:
+            if repo.name == target_repo:
+                return repo
+        else:
+            logger.error(
+                "Could not access {}. Please make sure the "
+                "GITHUB_TOKEN is valid.".format(target_repo)
+            )
+            sys.exit(1)
+
+    def _action_str(self, action):
+        return '{}: {}'.format(self.name, action)
 
 
 @click.command()
@@ -35,47 +110,16 @@ def main(pr_number):
     Checks a pull request on edx-platform to see if tests are finished. If they
     are, it comments on the PR to notify the user. If not, the script exits.
     """
-    github_token = _get_github_token()
-    github_instance = Github(github_token)
-
-    repos_list = github_instance.get_user().get_repos()
-
-    repository = None
-    for repo in repos_list:
-        if repo.name == "edx-platform":
-            repository = repo
-
-    if not repository:
-        logger.error(
-            "Could not access edx-platform. Please make sure "
-            "the GITHUB_TOKEN is valid."
-        )
-        sys.exit(1)
+    bot = EdxStatusBot(token=_get_github_token())
+    repo = bot.get_repo('edx-platform')
 
     try:
-        pr_number_int = int(pr_number)
-        pull_request_object = repository.get_pull(pr_number_int)
+        pr = repo.get_pull(int(pr_number))
     except:
         logger.error("Invalid PR number given.")
         sys.exit(1)
-
-    head_commit = pull_request_object.get_commits().reversed[0]
-    for status in head_commit.get_combined_status().statuses:
-        if status.state == 'pending':
-            logger.info(
-                "Other tests are still pending on this PR. Exiting"
-            )
-            sys.exit()
-
-    comment = "Your PR has finished running tests."
-    try:
-        pull_request_object.create_issue_comment(comment)
-    except:
-        logger.error(
-            "Failed to add issue comment to PR."
-        )
-        sys.exit(1)
-    logger.info("Successfully commented on PR.")
+    else:
+        bot.act_on(pr)
 
 
 if __name__ == "__main__":

--- a/jenkins/edx-platform-test-notifier.py
+++ b/jenkins/edx-platform-test-notifier.py
@@ -24,7 +24,7 @@ def _get_github_token():
 class EdxStatusBot:
     """
     A status bot that can perform multiple actions on PRs.
-    
+
     Looks for lines of the form '{botname}: {action}' in a PR's body to
     determine what actions to take.
     """


### PR DESCRIPTION
This refactors the notification code a bit to make it more generic for any type of action on a PR, that can be taken given any kind of logic surrounding a PR.

The first addition to this is adding the ability to ignore the bot, e.g. through a line in the PR body.

To test this, open a PR on the edx-platform with `edx-status-bot: ignore` somewhere, run the job for this PR, and note that it'll ignore the PR. Then remove the line and re-run the job for that PR, and note that it does post something.