### PR TITLE
Remove old edx-status-bot messages from PR's

### DIFF
--- a/jenkins/edx-platform-test-notifier.py
+++ b/jenkins/edx-platform-test-notifier.py
@@ -63,6 +63,7 @@ class EdxStatusBot:
     def notify_tests_completed(self, pr):
         """Post a notification on the PR that tests have finished running."""
         comment = "Your PR has finished running tests."
+        self.delete_old_issue_comments(pr)
         try:
             pr.create_issue_comment(comment)
         except:
@@ -81,6 +82,15 @@ class EdxStatusBot:
                 break
         else:
             return True
+
+    def delete_old_issue_comments(self, pr):
+        comments = pr.get_issue_comments()
+        for comment in comments:
+            if comment.user.login == self.name:
+                logger.info(
+                    "Old comment found on PR. Deleting"
+                )
+                comment.delete()
 
     def get_repo(self, target_repo):
         repos = self.github.get_user().get_repos()


### PR DESCRIPTION
This bot is causing too much clutter on PR's. Deleting old messages before posting a new one alleviates this clutter and will hopefully get more people using this feature.