### PR TITLE
use toxEnv instead of djangoVersion

### DIFF
--- a/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-bok-choy-pr.groovy
@@ -5,12 +5,12 @@ def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("ghprbActualCommit")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
-def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+def toxEnv = build.environment.get("TOX_ENV") ?: ""
 
 // Any environment variables that you want to inject into the environment of
 // child jobs of this build flow should be added here (comma-separated,
 // in the format VARIABLE=VALUE)
-def envVarString = "DJANGO_VERSION=${djangoVersion}"
+def envVarString = "TOX_ENV=${toxEnv}"
 
 guard{
     parallel(

--- a/jenkins/flow/pr/edx-platform-lettuce-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-lettuce-pr.groovy
@@ -5,12 +5,12 @@ def toolbox = extension."build-flow-toolbox"
 def sha1 = build.environment.get("ghprbActualCommit")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
-def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+def toxEnv = build.environment.get("TOX_ENV") ?: ""
 
 // Any environment variables that you want to inject into the environment of
 // child jobs of this build flow should be added here (comma-separated,
 // in the format VARIABLE=VALUE)
-def envVarString = "DJANGO_VERSION=${djangoVersion}"
+def envVarString = "TOX_ENV=${toxEnv}"
 
 guard{
   parallel(

--- a/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-python-unittests-pr.groovy
@@ -7,14 +7,14 @@ def branch = build.environment.get("ghprbSourceBranch")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
 def coverageJob = build.environment.get("COVERAGE_JOB") ?: "edx-platform-unit-coverage"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
-def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+def toxEnv = build.environment.get("TOX_ENV") ?: ""
 def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
 def runCoverage = build.environment.get("RUN_COVERAGE") ?: "true"
 
 // Any environment variables that you want to inject into the environment of
 // child jobs of this build flow should be added here (comma-separated,
 // in the format VARIABLE=VALUE)
-def envVarString = "DJANGO_VERSION=${djangoVersion}, RUN_COVERAGE=${runCoverage}"
+def envVarString = "TOX_ENV=${toxEnv}, RUN_COVERAGE=${runCoverage}"
 
 guard{
     unit = parallel(

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -8,12 +8,12 @@ def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset
 def qualityDiffJob = build.environment.get("QUALITY_DIFF_JOB") ?: "edx-platform-quality-diff"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
 def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
-def djangoVersion = build.environment.get("DJANGO_VERSION") ?: " "
+def toxEnv = build.environment.get("TOX_ENV") ?: ""
 
 // Any environment variables that you want to inject into the environment of
 // child jobs of this build flow should be added here (comma-separated,
 // in the format VARIABLE=VALUE)
-def envVarString = "DJANGO_VERSION=${djangoVersion}"
+def envVarString = "TOX_ENV=${toxEnv}"
 
 guard{
     quality = parallel(


### PR DESCRIPTION
Following https://github.com/edx/edx-platform/pull/18377, this allows the tox environment variable to be passed from flow job to subset job. NOTE: this does not account for master jobs, which should be addressed in a separate ticket.