### PR TITLE
account for prs without bodies

### DIFF
--- a/jenkins/edx_platform_test_notifier.py
+++ b/jenkins/edx_platform_test_notifier.py
@@ -58,7 +58,7 @@ class EdxStatusBot:
         sys.exit()
 
     def ignore_marker(self, pr):
-        return self._action_str('ignore') in pr.body
+        return self._action_str('ignore') in unicode(pr.body)
 
     def delete_old_comments(self, pr):
         comments = pr.get_issue_comments()


### PR DESCRIPTION
I noticed a fair amount of notifier jobs failing recently. Here is the error msg:
```
00:00:03.082 Running test notifier script...
00:00:03.708 Traceback (most recent call last):
00:00:03.708   File "jenkins/edx_platform_test_notifier.py", line 160, in <module>
00:00:03.708     main()
00:00:03.708   File "/home/jenkins/workspace/edx-platform-test-notifier/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
00:00:03.709     return self.main(*args, **kwargs)
00:00:03.709   File "/home/jenkins/workspace/edx-platform-test-notifier/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py", line 697, in main
00:00:03.709     rv = self.invoke(ctx)
00:00:03.709   File "/home/jenkins/workspace/edx-platform-test-notifier/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
00:00:03.710     return ctx.invoke(self.callback, **ctx.params)
00:00:03.710   File "/home/jenkins/workspace/edx-platform-test-notifier/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
00:00:03.710     return callback(*args, **kwargs)
00:00:03.711   File "jenkins/edx_platform_test_notifier.py", line 156, in main
00:00:03.711     bot.act_on(pr)
00:00:03.711   File "jenkins/edx_platform_test_notifier.py", line 50, in act_on
00:00:03.711     if take_action(pr):
00:00:03.711   File "jenkins/edx_platform_test_notifier.py", line 61, in ignore_marker
00:00:03.711     return self._action_str('ignore') in pr.body
00:00:03.712 TypeError: argument of type 'NoneType' is not iterable
```
This should account for the case when a pull request has a None value for a body