### PR TITLE
fix codecov script to look at other statuses and add tests

### DIFF
--- a/jenkins/codecov_response_metrics.py
+++ b/jenkins/codecov_response_metrics.py
@@ -6,7 +6,7 @@
 
 # This script attempts to determine the extent of the issue. It scans a series
 # of repositories that are currently reporting coverage metrics to codecov,
-# and collects the lenght of time it took for codecov to post back a status context
+# and collects the length of time it took for codecov to post back a status context
 # (if at all).
 
 # This script should be run periodically in order to get a good understanding
@@ -28,7 +28,7 @@ REPOS = [
     'edx/edx-enterprise',
     'edx/ecommerce',
     'edx/studio-frontend',
-    'edx/xqueue'
+    'edx/xqueue',
     'edx/edx-gomatic',
     'edx/edx-drf-extensions',
     'edx/edx-analytics-dashboard',
@@ -36,7 +36,7 @@ REPOS = [
     'edx/credentials',
     'edx/course-discovery',
     'edx/edx-video-pipeline',
-    'edx/edx-analytics-pipeline'
+    'edx/edx-analytics-pipeline',
     'edx/completion',
     'edx/XBlock',
     'edx/edx-enterprise-data',
@@ -52,57 +52,174 @@ def is_recent(activity_time, time_frame=3600):
     determine if a timestamp occurred between now (UTC) and time_frame
     """
     activity_age = datetime.datetime.utcnow() - activity_time
-    answer = activity_age.total_seconds() < time_frame
-    return answer
+    return activity_age.total_seconds() < time_frame
+
+
+def is_head_recent(pull_request, time_frame=3600):
+    """
+    determine if the head commmit pull request has been pushed between now and
+    time_frame by seeing if any of the status contexts on the head commit were
+    posted within said time frame. This seems to be the only way to derive
+    this information, as the Github API does not serve information about when
+    a commit is pushed.
+    """
+    try:
+        head_commit = get_head_commit(pull_request)
+    except IndexError:
+        logger.info('{} has no commits. Skipping'.format(pull_request.title))
+        return False
+    statuses = head_commit.get_combined_status().statuses
+    return any(
+        [is_recent(dt, time_frame) for dt in [s.updated_at for s in statuses]]
+    )
 
 
 def get_recent_pull_requests(repo, time_frame=3600):
     """
-    given a repository, retrieve pull requests that have had activity within
-    a time frame
+    given a repository, retrieve all pull requests that have received
+    updated status contexts within a given time frame
     """
-    # debug
-    logger.info(repo.full_name)
-    num = repo.get_pulls()
-    recent_pull_requests = [
-        pr for pr in repo.get_pulls() if is_recent(pr.updated_at, time_frame)
-    ]
-    logger.info("Found {} recent pull requests".format(len(recent_pull_requests)))
+    recent_pull_requests = []
+    for pr in repo.get_pulls(state="all", sort="updated", direction="desc"):
+        # since the pull requests are sorted by 'updated_at', once we reach
+        # pull requests that have not been updated in a week, stop searching
+        if not is_recent(pr.updated_at, 604800):
+            break
+        if is_head_recent(pr, time_frame):
+            recent_pull_requests.append(pr)
+
+    logger.info("Found {} recent pull requests".format(
+        len(recent_pull_requests)
+    ))
     return recent_pull_requests
 
 
-def get_commit_time(commit):
+def get_head_commit(pull_request):
+    return pull_request.get_commits().reversed[0]
+
+
+def has_context_posted(context_name, statuses):
+    return context_name in [status.context for status in statuses]
+
+
+def get_context_update_time(context, statuses):
+    return filter(
+        lambda x: x.context == context, statuses
+    )[0].updated_at.replace(microsecond=0)
+
+
+def get_context_state(context, statuses):
+    return filter(lambda s: s.context == context, statuses)[0].state
+
+
+def get_context_age(statuses, codecov_context, trigger_context):
     """
-    return the time that a given commit was pushed
+    get the age of a given codecov context. This is done by computing
+    the difference between when the context that triggers codecov was
+    posted and when codecov results were posted, or, in the case that
+    they haven't yet, now.
     """
-    return datetime.datetime.strptime(
-        commit.last_modified, "%a, %d %b %Y %H:%M:%S %Z"
+    # get the context that should trigger the codecov context
+    trigger_context_update_time = get_context_update_time(
+        trigger_context, statuses
     )
 
-
-def get_context_age(commit, context_name):
-    """
-    Given a commit and a context (i.e. 'codecov/patch'), determine:
-    a) if the context has been posted onto the commit
-    b) the age of the context update. In other words, the time diff between
-    the commit being pushed and the context being posted
-    """
-    commit_received_at = get_commit_time(commit)
-    statuses = commit.get_combined_status().statuses
-    if context_name in [c.context for c in statuses]:
-        context = filter(lambda x: x.context == context_name, statuses)[0]
-        context_age = context.updated_at - commit_received_at
-        context_age_in_seconds = context_age.total_seconds()
-        log_msg = "'{}' posted within {}s of the commit being pushed".format(
-            context_name, context_age_in_seconds
+    if has_context_posted(codecov_context, statuses):
+        codecov_context_update_time = get_context_update_time(
+            codecov_context, statuses
         )
-        return True, context_age_in_seconds
+        context_age = codecov_context_update_time - trigger_context_update_time
+        logger.info("'{}' posted {} seconds after {} was posted".format(
+            codecov_context, context_age, trigger_context
+        ))
+        posted = True
     else:
-        current_age = datetime.datetime.utcnow() - commit_received_at
-        current_age_in_seconds = current_age.total_seconds()
-        logger.info("'{}' has not posted {}s after commit was pushed".format(
-            context_name, current_age_in_seconds))
-        return False, current_age_in_seconds
+        current_timestamp = datetime.datetime.utcnow().replace(microsecond=0)
+        context_age = current_timestamp - trigger_context_update_time
+        logger.info(
+            "'{}' has still not posted {} seconds after {} was posted".format(
+                codecov_context, context_age, trigger_context
+            )
+        )
+        posted = False
+    context_age_in_seconds = int(context_age.total_seconds())
+    # occasionally, codecov can be posted back to the pull request before
+    # travis. This is the case in which a complex travis file runs different
+    # sharded tasks, one of which submits coverage data. This will result
+    # in a negative age for the codecov context. Treat these as 0, since
+    # their impact is not important.
+    if context_age_in_seconds < 0:
+        context_age_in_seconds = 0
+    return posted, context_age_in_seconds, trigger_context_update_time
+
+
+def gather_codecov_metrics(all_repos, time_frame):
+    """
+    scan all pertinent repos for metrics on how long it took for codecov
+    to report back following a 'triggering' context posting back to a
+    pull request. Return a list of JSON objects storing this data.
+    """
+    logger.info(
+        'Gathering codecov response metrics on pull requests ' +
+        'updated within the last {} seconds'.format(time_frame)
+    )
+
+    results = []
+
+    for repo in [r for r in all_repos if r.full_name in REPOS]:
+
+        logger.info('Checking {} for recent PRs'.format(repo.full_name))
+        prs = get_recent_pull_requests(repo, time_frame=time_frame)
+        # skip repos not updated within this 'time_frame'
+        if not prs:
+            logger.info(
+                'No recent pull requests found in {}.'.format(repo.full_name)
+            )
+            continue
+
+        for pr in prs:
+            pr_title = unicode(pr.title)
+            logger.info('Analyzing pr {}'.format(pr_title))
+            head_commit = get_head_commit(pr)
+            head_status = head_commit.get_combined_status().statuses
+            # mapping of status contexts that generate code coverage data
+            # and send it to codecov to the codecov status contexts for
+            # said data
+            context_map = {
+                'continuous-integration/travis-ci/pr': 'codecov/patch',
+                'continuous-integration/travis-ci/push': 'codecov/project',
+                'jenkins/python': 'codecov/project'
+            }
+            for trigger_context, codecov_context in context_map.iteritems():
+                # skip prs that have not been posted to by their trigger status
+                if not has_context_posted(trigger_context, head_status):
+                    logger.info(
+                        "Context '{}' has not posted yet. Skipping".format(
+                            trigger_context
+                        )
+                    )
+                    continue
+                # skip prs in which the trigger context has failed. This means
+                # that coverage results have not been sent to codecov
+                if get_context_state(trigger_context, head_status) != 'success':
+                    logger.info("Context '{}' failed. Skipping".format(
+                        trigger_context
+                    ))
+                    continue
+                posted, context_age, trigger_posted_at = get_context_age(
+                    head_status, codecov_context, trigger_context
+                )
+                result = {
+                    'repo': repo.full_name,
+                    'pull_request': pr_title,
+                    'commit': head_commit.sha,
+                    'trigger_context_posted_at': str(trigger_posted_at),
+                    'codecov_received':  posted,
+                    'codecov_received_after': context_age,
+                    'context': codecov_context
+                }
+                results.append(result)
+    return results
 
 
 def main():
@@ -110,60 +227,24 @@ def main():
         token = os.environ.get('GITHUB_TOKEN')
     except KeyError:
         logger.error('No value set for GITHUB_TOKEN. Please try again')
-        sys.extit(1)
+        sys.exit(1)
 
     gh = Github(token)
     # Only consider pull requests created within this time frame (in seconds)
-    pull_request_time_frame = os.environ.get('PULL_REQUEST_TIME_FRAME', 3600)
-
-    logger.info(
-        'Gathering codecov response metrics on pull requests ' +
-        'updated within the last {} seconds'.format(pull_request_time_frame)
-    )
-
-    results = []
+    time_frame = os.environ.get('PULL_REQUEST_TIME_FRAME', 3600)
 
     all_repos = gh.get_user().get_repos()
-    for repo in [r for r in all_repos if r.full_name in REPOS]:
-
-        logging.info('Searching for recent pull requests in {}'.format(repo.full_name))
-        # skip repos not updated within this 'time_frame'
-        prs = get_recent_pull_requests(repo, time_frame=pull_request_time_frame)
-        if not prs:
-            logger.info(
-                'Repo {} does not contain any recent pull requests.'.format(repo.full_name)
-            )
-            continue
-
-        for pr in prs:
-            newest_commit = pr.get_commits().reversed[0]
-            pr_title = unicode(pr.title)
-            logger.info(u"Analyzing commit {} on pull request '{}'".format(
-                newest_commit.sha, pr_title))
-            for context in ['codecov/project', 'codecov/patch']:
-                # edx-platform does not run codecov/patch, so skip it
-                if repo.full_name == 'edx/edx-platform' and context == 'codecov/patch':
-                    continue
-                posted, context_age = get_context_age(newest_commit, context)
-                result = {
-                    'repo': repo.full_name,
-                    'pull_request': pr_title,
-                    'commit': newest_commit.sha,
-                    'commit_pushed_at': str(get_commit_time(newest_commit)),
-                    'codecov_received':  posted,
-                    'codecov_received_at': context_age
-                }
-                results.append(result)
+    results = gather_codecov_metrics(all_repos, time_frame)
 
     json_data = {'results': results}
     outfile_name = 'codecov_metrics.json'
     try:
         logger.info('Writing results to {}'.format(outfile_name))
-        with open(outfile_name, 'a') as outfile:
+        with open(outfile_name, 'w') as outfile:
             json.dump(json_data, outfile, separators=(',', ':'))
             outfile.write('\n')
     except OSError:
-        logger.error('Unable to write data to {}'.foramt(outfile_name))
+        logger.error('Unable to write data to {}'.format(outfile_name))
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/jenkins/tests/test_codecov_analysis.py
+++ b/jenkins/tests/test_codecov_analysis.py
@@ -1,0 +1,178 @@
+from unittest import TestCase
+
+import datetime
+
+from mock import patch, Mock
+
+from jenkins.codecov_response_metrics import (
+    get_recent_pull_requests,
+    get_context_age,
+    gather_codecov_metrics
+)
+
+
+class MockRepo(object):
+
+    def __init__(self, full_name, prs):
+        self.full_name = full_name
+        self.prs = prs
+
+    def get_pulls(self, state, sort, direction):
+        return self.prs
+
+
+class MockPR(object):
+
+    def __init__(self, title, commits=[], age=10000):
+        self.title = title
+        self.commits = commits
+        self.updated_at = datetime.datetime.utcnow() - datetime.timedelta(seconds=age)
+
+    def get_commits(self):
+        return self
+
+    @property
+    def reversed(self):
+        return self.commits[::-1]
+
+
+class MockCommit(object):
+
+    def __init__(self, combined_status, sha=123):
+        self.combined_status = combined_status
+        self.sha = sha
+
+    def get_combined_status(self):
+        return self.combined_status
+
+
+class MockCombinedStatus(object):
+
+    def __init__(self, statuses):
+        self.statuses = statuses
+
+
+class MockStatus(object):
+
+    def __init__(self, context, age, state='success'):
+        self.context = context
+        self.updated_at = datetime.datetime.utcnow() - datetime.timedelta(seconds=age)
+        self.state = state
+
+
+class CodeCovTest(TestCase):
+
+    def test_recent_pull_request(self):
+
+        # pull request in which the HEAD commit has no 'recent' status contexts
+        mocked_old_combined_status = MockCombinedStatus(
+            [
+                MockStatus('A', 1000),
+                MockStatus('B', 1000),
+                MockStatus('C', 2000)
+            ]
+        )
+        mocked_old_commit = MockCommit(mocked_old_combined_status)
+        mocked_old_pr = MockPR('My PR', [None, None, mocked_old_commit])
+
+        # pull request in which at least one status context is 'recent' on
+        # the HEAD commit
+        mocked_new_combined_status = MockCombinedStatus(
+            [
+                MockStatus('A', 1000),
+                MockStatus('B', 100),
+                MockStatus('C', 2000)
+            ]
+        )
+        mocked_new_commit = MockCommit(mocked_new_combined_status)
+        mocked_new_pr = MockPR('Test Pr', [None, None, None, mocked_new_commit])
+
+        mocked_repo = MockRepo('mock/repo', [mocked_old_pr, mocked_new_pr])
+
+        recent_pull_requests = get_recent_pull_requests(mocked_repo, 500)
+        self.assertEqual(len(recent_pull_requests), 1)
+        self.assertEqual(recent_pull_requests[0].title, 'Test Pr')
+
+    def test_context_age_calculation(self):
+        mocked_combined_status = MockCombinedStatus(
+            [
+                MockStatus('A', 10),
+                MockStatus('B', 1000),
+                MockStatus('C', 500),
+                MockStatus('D', 100)
+            ]
+        )
+        posted, context_age, _ = get_context_age(
+            mocked_combined_status.statuses, 'D', 'B'
+        )
+        self.assertTrue(posted)
+        self.assertEqual(context_age, 900)
+
+    def test_context_age_calculation_not_present(self):
+        mocked_combined_status = MockCombinedStatus(
+            [
+                MockStatus('A', 10),
+                MockStatus('B', 100),
+                MockStatus('C', 500)
+            ]
+        )
+        posted, context_age, _ = get_context_age(
+            mocked_combined_status.statuses, 'D', 'B'
+        )
+        self.assertFalse(posted)
+        self.assertEqual(context_age, 100)
+
+    def test_trigger_contexts_not_present(self):
+        mocked_combined_status_without_triggers = MockCombinedStatus(
+            [
+                MockStatus('A', 10),
+                MockStatus('B', 1000),
+                MockStatus('C', 500),
+                MockStatus('D', 100)
+            ]
+        )
+        mocked_combined_status_with_triggers = MockCombinedStatus(
+            [
+                MockStatus('continuous-integration/travis-ci/pr', 2000),
+                MockStatus('continuous-integration/travis-ci/push', 1000),
+                MockStatus('codecov/patch', 500),
+                MockStatus('codecov/project', 100)
+            ]
+        )
+        mocked_commit_1 = MockCommit(
+            mocked_combined_status_without_triggers, 1111
+        )
+        mocked_commit_2 = MockCommit(
+            mocked_combined_status_with_triggers, 2222
+        )
+
+        mocked_prs = [
+            MockPR('pr #1', [None, None, mocked_commit_1]),
+            MockPR('pr #2', [None, None, None, mocked_commit_2])
+        ]
+        mocked_repos = [MockRepo('edx/ecommerce', mocked_prs)]
+
+        metrics = gather_codecov_metrics(mocked_repos, 5000)
+
+        now = datetime.datetime.utcnow().replace(microsecond=0)
+        expected_results = [
+            {
+                'repo': 'edx/ecommerce',
+                'pull_request': 'pr #2',
+                'commit': 2222,
+                'trigger_context_posted_at': str(now - datetime.timedelta(seconds=2000)),
+                'codecov_received':  True,
+                'codecov_received_after': 1500,
+                'context': 'codecov/patch'
+            },
+            {
+                'repo': 'edx/ecommerce',
+                'pull_request': 'pr #2',
+                'commit': 2222,
+                'trigger_context_posted_at': str(now - datetime.timedelta(seconds=1000)),
+                'codecov_received':  True,
+                'codecov_received_after': 900,
+                'context': 'codecov/project'
+            }
+        ]
+        self.assertEqual(metrics, expected_results)


### PR DESCRIPTION
This has a couple of changes to the codecov analysis script:
* rather than checking the diff between when the commit was pushed (which is an unreliable metric offered by the Github API), look at the diff between a triggering context (i.e. unit tests/travis) and codecov posting on the pull request
* add additional checking for corner cases (i.e. no need to check codecov if unit tests fail and therefore don't send coverage data)
* add tests