### PR TITLE
handle prs with 0 commits in test notifier script

### DIFF
--- a/jenkins/edx_platform_test_notifier.py
+++ b/jenkins/edx_platform_test_notifier.py
@@ -84,6 +84,11 @@ class EdxStatusBot:
             logger.info("Successfully commented on PR.")
 
     def get_head_commit(self, pr):
+        """
+        Return the HEAD commit from a given pull request. Occasionally, a pull
+        request can have no commits (for instance, if it has been reset). In
+        this case, exit the script, as there is nothing else to do.
+        """
         commits = pr.get_commits()
         if not list(commits):
             logger.error("This pull request has no commits. Exiting.")

--- a/jenkins/edx_platform_test_notifier.py
+++ b/jenkins/edx_platform_test_notifier.py
@@ -83,8 +83,16 @@ class EdxStatusBot:
         else:
             logger.info("Successfully commented on PR.")
 
+    def get_head_commit(self, pr):
+        commits = pr.get_commits()
+        if not list(commits):
+            logger.error("This pull request has no commits. Exiting.")
+            sys.exit()
+        head_commit = commits.reversed[0]
+        return head_commit
+
     def notify_tests_completed_marker(self, pr):
-        head_commit = pr.get_commits().reversed[0]
+        head_commit = self.get_head_commit(pr)
         for status in head_commit.get_combined_status().statuses:
             if status.state == 'pending':
                 logger.info(
@@ -109,10 +117,10 @@ class EdxStatusBot:
 
     def get_failures(self, pr):
         """ return a list of the contexts that recently failed on a given pr """
-        head = pr.get_commits().reversed[0]
+        head_commit = self.get_head_commit(pr)
         failures = filter(
             lambda status: status.state in ["failure", "error"],
-            head.get_combined_status().statuses
+            head_commit.get_combined_status().statuses
         )
         return map(lambda status: status.context, failures)
 


### PR DESCRIPTION
Sometimes, a PR can have no commits. This can occur due to a reset/rebase. Here is an example: https://github.com/edx/edx-platform/pull/18758

I ran the code we use to get pull requests in the notifier script on the last 300 PRs into the edx-platform and this is the only scenario I could find that causes the following error:
```
Running test notifier script...
Traceback (most recent call last):
  File "jenkins/edx_platform_test_notifier.py", line 160, in <module>
    main()
  File "<https://build.testeng.edx.org/job/edx-platform-test-notifier/ws/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py",> line 722, in __call__
    return self.main(*args, **kwargs)
  File "<https://build.testeng.edx.org/job/edx-platform-test-notifier/ws/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py",> line 697, in main
    rv = self.invoke(ctx)
  File "<https://build.testeng.edx.org/job/edx-platform-test-notifier/ws/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py",> line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "<https://build.testeng.edx.org/job/edx-platform-test-notifier/ws/test_notifier_venv/local/lib/python2.7/site-packages/click/core.py",> line 535, in invoke
    return callback(*args, **kwargs)
  File "jenkins/edx_platform_test_notifier.py", line 156, in main
    bot.act_on(pr)
  File "jenkins/edx_platform_test_notifier.py", line 50, in act_on
    if take_action(pr):
  File "jenkins/edx_platform_test_notifier.py", line 87, in notify_tests_completed_marker
    head_commit = pr.get_commits().reversed[0]
  File "<https://build.testeng.edx.org/job/edx-platform-test-notifier/ws/test_notifier_venv/local/lib/python2.7/site-packages/github/PaginatedList.py",> line 41, in __getitem__
    return self.__elements[index]
IndexError: list index out of range
```
This PR will cause the script to gracefully bail in case it detects this state.