### PR TITLE
Add script to get ordered test list from Jenkins console output

### DIFF
--- a/jenkins/get_ordered_test_list.py
+++ b/jenkins/get_ordered_test_list.py
@@ -1,4 +1,12 @@
+"""
+This script strips the console log of a pytest-xdist Jenkins run into the test list
+of an individual worker.
+
+Assumes the following format:
+[test-suite] [worker] RESULT test
+    """
 import click
+import io
 
 
 @click.command()
@@ -19,21 +27,14 @@ import click
     required=True
 )
 def main(log_file, worker, test_suite):
-    """
-    Strips the console log of a pytest-xdist Jenkins run into the test list
-    of an individual worker.
-
-    Assumes a format of:
-    [test-suite] [worker] RESULT test
-    """
     test_string_prefix = "[{}] [{}]".format(test_suite, worker)
     test_list_file = '{}_{}_test_list.txt'.format(test_suite, worker)
     outputFileOpened = False
-    with open(log_file, 'r') as console_file:
+    with io.open(log_file, 'r') as console_file:
         for line in console_file:
             if test_string_prefix in line:
                 if not outputFileOpened:
-                    output_file = open(test_list_file, 'w')
+                    output_file = io.open(test_list_file, 'w')
                     outputFileOpened = True
                 output_file.write(line.split()[3]+'\n')
 

--- a/jenkins/get_ordered_test_list.py
+++ b/jenkins/get_ordered_test_list.py
@@ -1,0 +1,47 @@
+import click
+
+
+@click.command()
+@click.option(
+    '--log-file',
+    help="File name of console log .txt file from a Jenkins build "
+    "that ran pytest-xdist.",
+    required=True
+)
+@click.option(
+    '--worker',
+    help="Pytest worker that ran the test list. Example: gw0",
+    required=True
+)
+@click.option(
+    '--test-suite',
+    help="Test suite that the pytest worker ran. Example: lms-unit",
+    required=True
+)
+def main(log_file, worker, test_suite):
+    """
+    Strips the console log of a pytest-xdist Jenkins run into the test list
+    of an individual worker.
+
+    Assumes a format of:
+    [test-suite] [worker] RESULT test
+    """
+    test_string_prefix = "[{}] [{}]".format(test_suite, worker)
+    test_list_file = '{}_{}_test_list.txt'.format(test_suite, worker)
+    outputFileOpened = False
+    with open(log_file, 'r') as console_file:
+        for line in console_file:
+            if test_string_prefix in line:
+                if not outputFileOpened:
+                    output_file = open(test_list_file, 'w')
+                    outputFileOpened = True
+                output_file.write(line.split()[3]+'\n')
+
+    if outputFileOpened:
+        output_file.close()
+    else:
+        raise StandardError("No tests found for test-suite: {} and worker: {}".format(test_suite, worker))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The point of this script is to take a console log file from Jenkins (that ran tests with pytest-xdist) and generate the exact test order of a worker, so that it can be used for debugging purposes to diagnose test flakes.

1- I'm not sure if this is where we should store the script now or in the long run. But it seems to somewhat be consistent with other Jenkins-y scripts. If we were to extend this further and automatically run it on platform PR's that fail, it  would probably be worth throwing in edx-platform.
2- I considered more reg ex'ing for this script, but realized I would be making similar assumptions as I am with using `split` about the formatting of the file.