### PR TITLE
Add target branch to quality flow script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ branches:
       - master
 python:
   - "2.7"
+before_install:
+  - export BOTO_CONFIG=/dev/null
 install:
   - pip install -r requirements/testing.txt
 script:

--- a/jenkins/flow/pr/edx-platform-quality-pr.groovy
+++ b/jenkins/flow/pr/edx-platform-quality-pr.groovy
@@ -7,13 +7,13 @@ def branch = build.environment.get("ghprbSourceBranch")
 def subsetJob = build.environment.get("SUBSET_JOB") ?: "edx-platform-test-subset"
 def qualityDiffJob = build.environment.get("DIFF_JOB") ?: "edx-platform-quality-diff"
 def workerLabel = build.environment.get("WORKER_LABEL") ?: "jenkins-worker"
-def targetBranch = build.environment.get("TARGET_BRANCH") ?: "origin/master"
+def targetBranch = build.environment.get("ghprbTargetBranch") ?: "origin/master"
 def toxEnv = build.environment.get("TOX_ENV") ?: " "
 
 // Any environment variables that you want to inject into the environment of
 // child jobs of this build flow should be added here (comma-separated,
 // in the format VARIABLE=VALUE)
-def envVarString = "TOX_ENV=${toxEnv}"
+def envVarString = "TARGET_BRANCH=${targetBranch}, TOX_ENV=${toxEnv}"
 
 guard{
     quality = parallel(


### PR DESCRIPTION
Add env var for target branch so that quality shard 4 can run xsscomitlinter against the proper target branch.

There seems to be something wrong with the envVarString, as I can only access the first variable when running the edx-platform scripts. I can continue to look into this separately.. or we can just move on in favor of pipelines since (I think) the tox env is just being set to null in all of our active jobs anyways. We'll of course need it to be functional in python3 jobs, but we're moving those over to pipelines this sprint anyways.

Also, Travis has been failing due to the following exception:

```
ImportError: No module named google_compute_engine
```

We've patched this in at least one other edx repo (edx/edx-analytics-pipeline#424) with export BOTO_CONFIG=/dev/null.