### PR TITLE
add script to generate incr tickets

### DIFF
--- a/scripts/create_incr_tickets.py
+++ b/scripts/create_incr_tickets.py
@@ -1,0 +1,176 @@
+import os
+import sys
+from collections import namedtuple
+
+# We should aspire to create batches of less than 15 python files
+# although this is not a strict limit. Setting a target of 10 files,
+# will on average yield batches of 10-15.
+TARGET_FILE_NUMBER = 10
+
+
+class Batch(object):
+    """
+    representation of a `batch` of python files for ticketing purposes
+
+    the `root` of the batch is the greatest common path, given a list of
+    files
+
+    a batch is considered `blocked` if there exist other batches that
+    contain files deeper in the path than this batch's root. This value
+    is used to denote the fact this this batch should not be worked on
+    or ticketed until the blocking batch has been completed
+    """
+
+    def __init__(self, root):
+        self.root = root
+        self.files = []
+        self.blocked = False
+
+    def __str__(self):
+        return "{} :: {}".format(self.root, len(self.files))
+
+    def add(self, file_path):
+        self.files.append(file_path)
+        self.rebalance_root()
+
+    def remove(self, file_path):
+        self.files.remove(file_path)
+        self.rebalance_root()
+
+    def contains_file(self, file_path):
+        return file_path in self.files
+
+    def contains_dir(self, dir_path):
+        return dir_path in self.directories
+
+    @property
+    def directories(self):
+        """
+        return a list of all of the directories contained within this batch
+        of files.
+        """
+        directories = list(set([
+            '/'.join(f.split('/')[:-1]) for f in self.files
+        ]))
+        return sorted(directories)
+
+    @property
+    def top_level_directories(self):
+        """
+        return a list of all of the top level directories in this batch of
+        files, that is, all of the directories that are not contained in other
+        directories in this batch
+        """
+        top_level_directories = filter(
+            lambda d: len([x for x in self.directories if x in d]) == 1,
+            self.directories
+        )
+        return top_level_directories
+
+    def rebalance_root(self):
+        """
+        update the root of this batch after a file has been added, in case
+        their paths differ. For example:
+
+        if this batch had a root of /a/b/c and we add a file from /a/b/d,
+        the newly balanced root should be /a/b
+        """
+        split_dirs = map(lambda d: d.split('/'), self.directories)
+        new_root = []
+        for level in zip(*split_dirs):
+            if not(all(map(lambda d: d == level[0], level))):
+                break
+            new_root.append(level[0])
+        self.root = '/'.join(new_root)
+
+    def file_count(self):
+        return len(self.files)
+
+    def blocks(self, dirs):
+        """
+        determine if this batch of files blocks work on another batch of
+        files. This is the case when a path (contained in this
+        batch) is a child of a directory in the list `dirs`.
+        """
+        return any(map(lambda d: d in self.directories, dirs))
+
+    def base_similar(self, other_root):
+        """
+        determine if this batch has a root that is similar to another- that is,
+        it is either the same, is a subdirectory, or they share a common parent
+        """
+        if self.root == other_root:
+            return True
+        elif self.root.split('/')[:-1] == other_root.split('/')[:-1]:
+            return True
+        elif other_root in self.root:
+            return True
+        else:
+            return False
+
+
+def check_if_blocked(batches, root, dirs):
+    """
+    check if any of the batches that have already been grouped are
+    contained, as sub directories, in a given root and it's children
+    directories
+    """
+    paths = [os.path.join(root, d) for d in dirs]
+    return any(map(lambda b: b.blocks(paths), batches))
+
+
+def filter_python_files(files):
+    """
+    given a list of files, extract the python files
+    """
+    return [f for f in files if f.endswith('.py')]
+
+
+def crawl(path, TARGET_FILE_NUMBER):
+    """
+    crawl a given file path, from the deepest node up, collecting and
+    organizing directories containing python files into `Batches` of less
+    than `TARGET_FILE_NUMBER` python files.
+    """
+    batches = []
+    in_a_batch = False
+
+    for root, dirs, files in os.walk(path, topdown=False):
+        # skip directories that have no python files
+        if len(filter_python_files(files)) < 1:
+            continue
+        if not in_a_batch:
+            current_batch = Batch(root)
+            in_a_batch = True
+        if not current_batch.base_similar(root):
+            batches.append(current_batch)
+            current_batch = Batch(root)
+            in_a_batch = True
+        # mark this batch as `blocked` if any of the subdirectories in the
+        # current node have already been added to the list of batches
+        if check_if_blocked(batches, root, dirs):
+            current_batch.blocked = True
+        python_files = [os.path.join(root, f) for f in filter_python_files(files)]
+        for file_path in python_files:
+            current_batch.add(file_path)
+        if current_batch.file_count() >= TARGET_FILE_NUMBER:
+            batches.append(current_batch)
+            in_a_batch = False
+    if in_a_batch:
+        batches.append(current_batch)
+    return batches
+
+
+def main():
+    path = sys.argv[1]
+    batches = crawl(path, TARGET_FILE_NUMBER)
+    with open('output.csv', 'w') as out:
+        out.write('BLOCKED, NUMBER OF PYTHON FILES, DIRECTORIES')
+        out.write('\n')
+        for b in batches:
+            dirs = ':'.join(b.top_level_directories)
+            out.write('{},{},{}'.format(b.blocked, b.file_count(), dirs))
+            out.write('\n')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,26 @@
+mkdir -p happy_path
+touch happy_path/a.py
+touch happy_path/b.py
+touch happy_path/c.py
+mkdir -p multi_dir/a
+touch multi_dir/a/a1.py
+touch multi_dir/a/a2.py
+mkdir -p multi_dir/b
+touch multi_dir/b/b1.py
+mkdir -p multi_dir/c
+touch multi_dir/c/c1.py
+touch multi_dir/c/c2.py
+mkdir -p dependencies/dir/sub-dir
+touch dependencies/dir/a.py
+touch dependencies/dir/b.py
+touch dependencies/dir/sub-dir/c.py
+touch dependencies/dir/sub-dir/d.py
+touch dependencies/dir/sub-dir/e.py
+mkdir -p local/then_this
+touch local/then_this/c1.py
+mkdir -p local/this_first/dir/sub1
+touch local/this_first/dir/sub1/b1.py
+mkdir -p local/this_first/dir/sub2
+touch local/this_first/dir/sub2/a1.py
+touch local/this_first/dir/sub2/a2.py
+touch local/this_first/dir/sub2/a3.py

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,0 +1,90 @@
+import os
+from create_incr_tickets import Batch, crawl
+
+BASE = os.getcwd()
+
+
+def test_dirs():
+
+    batch = Batch('root')
+    files = [
+        'food/fruit/berries/blueberries.py',
+        'food/fruit/berries/blackberries.py',
+        'food/fruit/apples.py',
+        'food/fruit/bananas.py',
+        'furniture/chair.py',
+        'furniture/table.py'
+    ]
+
+    for f in files:
+        batch.add(f)
+    expected_dirs = [
+        'food/fruit',
+        'food/fruit/berries',
+        'furniture'
+    ]
+    assert batch.directories == expected_dirs
+
+    expected_dirs = ['food/fruit', 'furniture']
+    assert batch.top_level_directories == expected_dirs
+
+
+def test_rebalanced_root():
+
+    batch = Batch('food/fruit/berries')
+    batch.add('food/fruit/berries/raspberries.py')
+    assert batch.root == 'food/fruit/berries'
+    batch.add('food/fruit/apples.py')
+    assert batch.root == 'food/fruit'
+    batch.add('food/meat/poultry/chicken.py')
+    assert batch.root == 'food'
+
+
+def test_crawl_happy_path():
+    PATH = os.path.join(BASE, 'happy_path')
+    batches = crawl(PATH, 3)
+    assert len(batches) == 1
+    batch = batches[0]
+    assert len(batch.files) == 3
+    assert batch.root == PATH
+
+
+def test_crawl_multidir():
+    PATH = os.path.join(BASE, 'multi_dir')
+    batches = crawl(PATH, 3)
+    assert len(batches) == 2
+    complete_batch = batches[0]
+    assert len(complete_batch.files) == 3
+    assert complete_batch.root == PATH
+    incomplete_batch = batches[1]
+    assert len(incomplete_batch.files) == 2
+    assert incomplete_batch.root == PATH + '/a'
+
+
+def test_crawl_w_dependencies():
+    PATH = os.path.join(BASE, 'dependencies')
+    batches = crawl(PATH, 3)
+    assert len(batches) == 2
+    complete_batch = batches[0]
+    assert len(complete_batch.files) == 3
+    assert complete_batch.root == PATH + '/dir/sub-dir'
+    assert not complete_batch.blocked
+    incomplete_batch = batches[1]
+    assert len(incomplete_batch.files) == 2
+    assert incomplete_batch.root == PATH + '/dir'
+    assert incomplete_batch.blocked
+
+
+def test_local_batches():
+    PATH = os.path.join(BASE, 'local')
+    batches = crawl(PATH, 3)
+    assert len(batches) == 3
+    first_batch = batches[0]
+    assert len(first_batch.files) == 3
+    assert first_batch.root == PATH + "/this_first/dir/sub2"
+    second_batch = batches[1]
+    assert len(second_batch.files) == 1
+    assert second_batch.root == PATH + "/this_first/dir/sub1"
+    third_batch = batches[2]
+    assert len(third_batch.files) == 1
+    assert third_batch.root == PATH + "/then_this"


### PR DESCRIPTION
This is a helper script for analyzing a directory, and attempting to group sub directories containing a certain file type into small, fairly balanced batches. For now, it will dump a csv file listing each batch, describing how many python files are contained, which directories are contained, and if any of its sub-directories are present in other batches (meaning that they are blocked by the other).

There are some basic tests included. To run them, you need to first run `bash setup.sh` to set up the necessary directory structure for the tests. I opted for this instead of using pytest fixtures, just because this may be a 1-time script

My intention is to add jira integration, to create a templated INCR ticket for each test batch.