### PR TITLE
add incr ticket numbers to output

### DIFF
--- a/scripts/create_incr_tickets.py
+++ b/scripts/create_incr_tickets.py
@@ -163,14 +163,27 @@ def crawl(path, TARGET_FILE_NUMBER):
 
 def main():
     path = sys.argv[1]
+    ticket_number_seed = int(sys.argv[2])
     batches = crawl(path, TARGET_FILE_NUMBER)
-    with open('output.csv', 'w') as out:
-        out.write('BLOCKED, NUMBER OF PYTHON FILES, DIRECTORIES')
-        out.write('\n')
-        for b in batches:
+
+    blocked_batches = [b for b in batches if b.blocked]
+    ready_batches = [b for b in batches if not b.blocked]
+
+    with open('ready_batches.csv', 'w') as out:
+        for b in ready_batches:
             dirs = ':'.join(b.top_level_directories)
-            out.write('{},{},{}'.format(b.blocked, b.file_count(), dirs))
+            ticket_number = "INCR-{}".format(ticket_number_seed)
+            out.write('{},{},{},{}'.format(ticket_number, b.blocked, b.file_count(), dirs))
             out.write('\n')
+            ticket_number_seed += 1
+
+    with open('blocked_batches.csv', 'w') as out:
+        for b in blocked_batches:
+            dirs = ':'.join(b.top_level_directories)
+            ticket_number = "INCR-{}".format(ticket_number_seed)
+            out.write('{},{},{},{}'.format(ticket_number, b.blocked, b.file_count(), dirs))
+            out.write('\n')
+            ticket_number_seed += 1
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
given an initial number for the next logical incr ticket to create, increment it and add it to the output csv for each batch to process

example output:
```
INCR-TICKET, BLOCKED, NUMBER OF PYTHON FILES, DIRECTORIES
INCR-232,False,9,../../edx-platform/lms/djangoapps/gating
INCR-233,False,14,../../edx-platform/lms/djangoapps/shoppingcart/management:../../edx-platform/lms/djangoapps/shoppingcart/tests
INCR-234,False,11,../../edx-platform/lms/djangoapps/shoppingcart/migrations:../../edx-platform/lms/djangoapps/shoppingcart/processors
INCR-235,True,12,../../edx-platform/lms/djangoapps/shoppingcart
INCR-236,False,9,../../edx-platform/lms/djangoapps/notes
INCR-237,False,5,../../edx-platform/lms/djangoapps/debug
INCR-238,False,15,../../edx-platform/lms/djangoapps/bulk_email/migrations:../../edx-platform/lms/djangoapps/bulk_email/tests
```