### PR TITLE
Handle absence of reviewers in calls to create_pull_request

### DIFF
--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -146,7 +146,15 @@ def create_pull_request(repository, title, body, base, head, user_reviewers=Gith
             base=base,
             head=head
         )
-        pull_request.create_review_request(reviewers=user_reviewers, team_reviewers=team_reviewers)
+        any_reviewers = (
+            user_reviewers is not GithubObject.NotSet or
+            team_reviewers is not GithubObject.NotSet
+        )
+        if any_reviewers:
+            pull_request.create_review_request(
+                reviewers=user_reviewers,
+                team_reviewers=team_reviewers,
+            )
         return pull_request
     except:
         raise Exception(


### PR DESCRIPTION
I recently merged [a PR to stop upgrade jobs from mentioning the Master's squad](https://github.com/edx/jenkins-job-dsl/pull/1007). Since our rotating support engineer gets alerted of the PRs via OpsGenie, the mentions were just causing inbox noise.

That change [caused our upgrade jobs to start failing](https://build.testeng.edx.org/job/completion-upgrade-python-requirements/64/console):
```
06:00:27 INFO:root:Authenticating with Github
06:00:27 INFO:root:Trying to connect to repo: completion
06:00:28 INFO:root:modified files: ['requirements/dev.txt', 'requirements/doc.txt', 'requirements/quality.txt', 'requirements/test.txt', 'requirements/travis.txt']
06:00:30 INFO:root:Checking if there's any old pull requests to delete
06:00:30 INFO:root:Creating a new pull request
06:00:31 Traceback (most recent call last):
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/testeng-ci/jenkins/github_helpers.py", line 149, in create_pull_request
06:00:31     pull_request.create_review_request(reviewers=user_reviewers, team_reviewers=team_reviewers)
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/github/PullRequest.py", line 472, in create_review_request
06:00:31     input=post_parameters
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/github/Requester.py", line 268, in requestJsonAndCheck
06:00:31     return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/github/Requester.py", line 279, in __check
06:00:31     raise self.__createException(status, responseHeaders, output)
06:00:31 github.GithubException.GithubException: 422 {"message": "Invalid request.\n\nNo subschema in \"anyOf\" matched.\n\"reviewers\" wasn't supplied.\n\"team_reviewers\" wasn't supplied.", "documentation_url": "https://developer.github.com/v3/pulls/review_requests/#create-a-review-request"}
06:00:31 
06:00:31 During handling of the above exception, another exception occurred:
06:00:31 
06:00:31 Traceback (most recent call last):
06:00:31   File "/usr/lib/python3.5/runpy.py", line 184, in _run_module_as_main
06:00:31     "__main__", mod_spec)
06:00:31   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
06:00:31     exec(code, run_globals)
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/testeng-ci/jenkins/upgrade_python_requirements.py", line 120, in <module>
06:00:31     main()  # pylint: disable=no-value-for-parameter
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/click/core.py", line 764, in __call__
06:00:31     return self.main(*args, **kwargs)
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/click/core.py", line 717, in main
06:00:31     rv = self.invoke(ctx)
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/click/core.py", line 956, in invoke
06:00:31     return ctx.invoke(self.callback, **ctx.params)
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/upgrade_venv/lib/python3.5/site-packages/click/core.py", line 555, in invoke
06:00:31     return callback(*args, **kwargs)
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/testeng-ci/jenkins/upgrade_python_requirements.py", line 113, in main
06:00:31     team_reviewers=team_reviewers
06:00:31   File "/home/jenkins/workspace/completion-upgrade-python-requirements/testeng-ci/jenkins/github_helpers.py", line 153, in create_pull_request
06:00:31     "Could not create pull request"
06:00:31 Exception: Could not create pull request
06:00:31 Build step 'Execute shell' marked build as failure
06:00:31 Email was triggered for: Always
06:00:31 Sending email for trigger: Always
06:00:31 Sending email to: masters-requirements-update@edx.opsgenie.net
06:00:31 Finished: FAILURE
```

Essentially, we can't create a review request with no reviewers. This PR aims to not call the `create_review_request` function when there are no reviewers. I honesetly have no idea how to test it.

@edx/masters-devs 