### PR TITLE
Simplify PR creator, add CLI

### DIFF
--- a/jenkins/cleanup_python_code.py
+++ b/jenkins/cleanup_python_code.py
@@ -11,8 +11,7 @@ from jenkins.pull_request_creator import PullRequestCreator
 @click.command()
 @click.option(
     '--sha',
-    help="Sha of the merge commit to base the new PR off of",
-    required=True,
+    help="DEPRECATED: Ignored, current SHA is read from repo now",
 )
 @click.option(
     '--repo_root',
@@ -54,7 +53,7 @@ def main(sha, repo_root, user_reviewers, team_reviewers, packages, scripts):
         "{1}"
     ).format(scripts, packages)
 
-    pull_request_creator = PullRequestCreator(sha=sha, repo_root=repo_root, branch_name=CODE_CLEANUP_BRANCH_NAME,
+    pull_request_creator = PullRequestCreator(repo_root=repo_root, branch_name=CODE_CLEANUP_BRANCH_NAME,
                                               user_reviewers=user_reviewers, team_reviewers=team_reviewers,
                                               commit_message=message, pr_title="Python Code Cleanup",
                                               pr_body=message)

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -60,6 +60,8 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
 
     # FIXME: Probably can end up picking repo from wrong org if two
     # repos have the same name in different orgs.
+    #
+    # Use repo_from_remote instead, and delete this when no longer in use.
     def connect_to_repo(self, github_instance, repo_name):
         """
         Get the repository object of the desired repo.

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -83,8 +83,8 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
         of names as``remote_name_filter``.
         """
         patterns = [
-            r"git@github\.com:([^/?#]+/[^/?#]+).git",
-            r"https?://(?:www\.)?github\.com/([^/?#]+/[^/?#]+)/?"
+            r"git@github\.com:(?P<name>[^/?#]+/[^/?#]+).git",
+            r"https?://(www\.)?github\.com/(?P<name>[^/?#]+/[^/?#]+)/?"
         ]
         for remote in Repo(repo_root).remotes:
             if remote_name_filter and remote.name not in remote_name_filter:
@@ -93,7 +93,7 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
                 for pattern in patterns:
                     m = re.fullmatch(pattern, url)
                     if m:
-                        fullname = m.group(1)
+                        fullname = m.group('name')
                         logger.info("Discovered repo %s in remotes", fullname)
                         return self.github_instance.get_repo(fullname)
         raise Exception("Could not find a Github URL among repo's remotes")

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -75,19 +75,19 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
             "credentials and try again.".format(repo_name)
         )
 
-    def repo_from_remote(self, repo_root, remote_name_filter=None):
+    def repo_from_remote(self, repo_root, remote_name_allow_list=None):
         """
         Get the repository object for a repository with a Github remote.
 
         Optionally restrict the remotes under consideration by passing a list
-        of names as``remote_name_filter``.
+        of names as``remote_name_allow_list``, e.g. ``['origin']``.
         """
         patterns = [
             r"git@github\.com:(?P<name>[^/?#]+/[^/?#]+).git",
             r"https?://(www\.)?github\.com/(?P<name>[^/?#]+/[^/?#]+)/?"
         ]
         for remote in Repo(repo_root).remotes:
-            if remote_name_filter and remote.name not in remote_name_filter:
+            if remote_name_allow_list and remote.name not in remote_name_allow_list:
                 continue
             for url in remote.urls:
                 for pattern in patterns:

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -85,8 +85,10 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
         of names as``remote_name_allow_list``, e.g. ``['origin']``.
         """
         patterns = [
-            r"git@github\.com:(?P<name>[^/?#]+/[^/?#]+).git",
-            r"https?://(www\.)?github\.com/(?P<name>[^/?#]+/[^/?#]+)(/|\.git)?"
+            r"git@github\.com:(?P<name>[^/?#]+/[^/?#]+?).git",
+            # Non-greedy match for repo name so that optional .git on
+            # end is not included in repo name match.
+            r"https?://(www\.)?github\.com/(?P<name>[^/?#]+/[^/?#]+?)(/|\.git)?"
         ]
         for remote in Repo(repo_root).remotes:
             if remote_name_allow_list and remote.name not in remote_name_allow_list:

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -86,7 +86,7 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
         """
         patterns = [
             r"git@github\.com:(?P<name>[^/?#]+/[^/?#]+).git",
-            r"https?://(www\.)?github\.com/(?P<name>[^/?#]+/[^/?#]+)/?"
+            r"https?://(www\.)?github\.com/(?P<name>[^/?#]+/[^/?#]+)(/|\.git)?"
         ]
         for remote in Repo(repo_root).remotes:
             if remote_name_allow_list and remote.name not in remote_name_allow_list:

--- a/jenkins/pull_request_creator.py
+++ b/jenkins/pull_request_creator.py
@@ -139,13 +139,15 @@ class PullRequestCreator:
 @click.option('--pr-body', required=True)
 @click.option(
     '--user-reviewers',
-    multiple=True,
-    required=True
+    default='',
+    help="Comma separated list of Github users to be tagged on pull requests"
 )
 @click.option(
     '--team-reviewers',
-    multiple=True,
-    required=True
+    default='',
+    help=("Comma separated list of Github teams to be tagged on pull requests. "
+          "NOTE: Teams must have explicit write access to the repo, or "
+          "Github will refuse to tag them.")
 )
 @click.option(
     '--delete-old-pull-requests/--no-delete-old-pull-requests',
@@ -170,9 +172,8 @@ def main(
         repo_root=repo_root,
         branch_name=base_branch_name, commit_message=commit_message,
         pr_title=pr_title, pr_body=pr_body,
-        # TODO: Accept lists in constructor, too (requires changes to existing callers)
-        user_reviewers=','.join(user_reviewers),
-        team_reviewers=','.join(team_reviewers)
+        user_reviewers=user_reviewers,
+        team_reviewers=team_reviewers
     )
     creator.create(delete_old_pull_requests)
 

--- a/jenkins/pull_request_creator.py
+++ b/jenkins/pull_request_creator.py
@@ -3,6 +3,8 @@ Class helps create GitHub Pull requests
 """
 # pylint: disable=missing-class-docstring,missing-function-docstring,attribute-defined-outside-init
 import logging
+
+import click
 from github import GithubObject
 
 from .github_helpers import GitHubHelper
@@ -14,17 +16,15 @@ LOGGER.setLevel(logging.INFO)
 
 class PullRequestCreator:
 
-    def __init__(self, sha, repo_root, branch_name, user_reviewers, team_reviewers, commit_message, pr_title,
-                 pr_body, org=''):
+    def __init__(self, repo_root, branch_name, user_reviewers, team_reviewers, commit_message, pr_title,
+                 pr_body):
         self.branch_name = branch_name
         self.pr_body = pr_body
         self.pr_title = pr_title
         self.commit_message = commit_message
         self.team_reviewers = team_reviewers
         self.user_reviewers = user_reviewers
-        self.org = org
         self.repo_root = repo_root
-        self.sha = sha
 
     github_helper = GitHubHelper()
 
@@ -35,7 +35,7 @@ class PullRequestCreator:
         return self.github_instance.get_user()
 
     def _set_repository(self):
-        self.repository = self.github_helper.connect_to_repo(self.github_instance, self.repository_name)
+        self.repository = self.github_helper.repo_from_remote(self.repo_root, ['origin'])
 
     def _set_modified_files_list(self):
         self.modified_files_list = self.github_helper.get_modified_files_list(self.repo_root)
@@ -48,15 +48,14 @@ class PullRequestCreator:
         self.github_instance = self._get_github_instance()
         self.user = self._get_user()
 
-        # Last folder in repo_root should be the repository
-        directory_list = self.repo_root.split("/")
-        self.repository_name = directory_list[-1]
-        LOGGER.info("Trying to connect to repo: {}".format(self.repository_name))
+        LOGGER.info("Trying to connect to repo")
         self._set_repository()
+        LOGGER.info("Connected to {}".format(self.repository))
         self._set_modified_files_list()
+        self.base_sha = self.github_helper.get_current_commit(self.repo_root)
 
     def _branch_exists(self):
-        self.branch = "refs/heads/jenkins/{}-{}".format(self.branch_name, self.sha[:7])
+        self.branch = "refs/heads/jenkins/{}-{}".format(self.branch_name, self.base_sha[:7])
         return self.github_helper.branch_exists(self.repository, self.branch)
 
     def _create_new_branch(self):
@@ -66,7 +65,7 @@ class PullRequestCreator:
             self.repo_root,
             self.modified_files_list,
             self.commit_message,
-            self.sha,
+            self.base_sha,
             self.user.name
         )
         self._create_branch(commit_sha)
@@ -101,8 +100,8 @@ class PullRequestCreator:
         for num, deleted_pull_number in enumerate(deleted_pulls):
             if num == 0:
                 self.pr_body += "\n\nDeleted obsolete pull_requests:"
-            self.pr_body += "\nhttps://github.com/{}/{}/pull/{}".format(self.org, self.repository_name,
-                                                                        deleted_pull_number)
+            self.pr_body += "\nhttps://github.com/{}/pull/{}".format(self.repository.full_name,
+                                                                     deleted_pull_number)
 
     def create(self, delete_old_pull_requests):
         self._set_github_data()
@@ -121,3 +120,62 @@ class PullRequestCreator:
             self.delete_old_pull_requests()
 
         self._create_new_pull_request()
+
+
+@click.command()
+@click.option(
+    '--repo-root',
+    type=click.Path(exists=True, dir_okay=True, file_okay=False),
+    required=True,
+    help="Directory containing local copy of repository"
+)
+@click.option(
+    '--base-branch-name',
+    required=True,
+    help="Base name for branch to create. Full branch name will be like jenkins/BASENAME-1234567."
+)
+@click.option('--commit-message', required=True)
+@click.option('--pr-title', required=True)
+@click.option('--pr-body', required=True)
+@click.option(
+    '--user-reviewers',
+    multiple=True,
+    required=True
+)
+@click.option(
+    '--team-reviewers',
+    multiple=True,
+    required=True
+)
+@click.option(
+    '--delete-old-pull-requests/--no-delete-old-pull-requests',
+    default=True,
+    help="If set, delete old branches with the same base branch name and close their PRs"
+)
+def main(
+    repo_root, base_branch_name,
+    commit_message, pr_title, pr_body,
+    user_reviewers, team_reviewers,
+    delete_old_pull_requests
+):
+    """
+    Create a pull request with these changes in the repo.
+
+    Required environment variables:
+
+    - GITHUB_TOKEN
+    - GITHUB_USER_EMAIL
+    """
+    creator = PullRequestCreator(
+        repo_root=repo_root,
+        branch_name=base_branch_name, commit_message=commit_message,
+        pr_title=pr_title, pr_body=pr_body,
+        # TODO: Accept lists in constructor, too (requires changes to existing callers)
+        user_reviewers=','.join(user_reviewers),
+        team_reviewers=','.join(team_reviewers)
+    )
+    creator.create(delete_old_pull_requests)
+
+
+if __name__ == '__main__':
+    main(auto_envvar_prefix="PR_CREATOR")  # pylint: disable=no-value-for-parameter, unexpected-keyword-arg

--- a/jenkins/tests/test_upgrade_python_requirements.py
+++ b/jenkins/tests/test_upgrade_python_requirements.py
@@ -14,8 +14,9 @@ class BokchoyPullRequestTestCase(TestCase):
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.close_existing_pull_requests',
            return_value=[])
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_github_instance', return_value=None)
-    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.connect_to_repo', return_value=None)
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.repo_from_remote', return_value=None)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_modified_files_list', return_value=None)
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_current_commit', return_value='1234567')
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.branch_exists', return_value=None)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.update_list_of_files', return_value=None)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.create_pull_request', return_value=None)
@@ -24,14 +25,15 @@ class BokchoyPullRequestTestCase(TestCase):
            return_value=Mock(name="fake name", login="fake login"))
     @patch('jenkins.github_helpers.GitHubHelper.delete_branch', return_value=None)
     def test_no_changes(self, delete_branch_mock, get_user_mock, create_branch_mock, create_pr_mock,
-                        update_files_mock, branch_exists_mock, modified_list_mock, repo_mock, authenticate_mock,
+                        update_files_mock, branch_exists_mock, current_commit_mock,
+                        modified_list_mock, repo_mock, authenticate_mock,
                         close_existing_prs_mock):
         """
         Ensure a merge with no changes to db files will not result in any updates.
         """
-        pull_request_creator = PullRequestCreator('--sha=123', '--repo_root=../../edx-platform', 'upgrade-branch', [],
+        pull_request_creator = PullRequestCreator('--repo_root=../../edx-platform', 'upgrade-branch', [],
                                                   [], 'Upgrade python requirements', 'Update python requirements',
-                                                  'make upgrade PR', '--org=edx')
+                                                  'make upgrade PR')
         pull_request_creator.create(True)
 
         assert authenticate_mock.called
@@ -46,9 +48,10 @@ class BokchoyPullRequestTestCase(TestCase):
            return_value=[])
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_github_instance',
            return_value=Mock())
-    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.connect_to_repo', return_value=Mock())
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.repo_from_remote', return_value=Mock())
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_modified_files_list',
            return_value=["requirements/edx/base.txt", "requirements/edx/coverage.txt"])
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_current_commit', return_value='1234567')
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.branch_exists', return_value=False)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.update_list_of_files', return_value=None)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.create_pull_request', return_value=None)
@@ -57,14 +60,15 @@ class BokchoyPullRequestTestCase(TestCase):
            return_value=Mock(name="fake name", login="fake login"))
     @patch('jenkins.github_helpers.GitHubHelper.delete_branch', return_value=None)
     def test_changes(self, delete_branch_mock, get_user_mock, create_branch_mock, create_pr_mock,
-                     update_files_mock, branch_exists_mock, modified_list_mock, repo_mock, authenticate_mock,
+                     update_files_mock, branch_exists_mock, current_commit_mock,
+                     modified_list_mock, repo_mock, authenticate_mock,
                      close_existing_prs_mock):
         """
         Ensure a merge with no changes to db files will not result in any updates.
         """
-        pull_request_creator = PullRequestCreator('--sha=123', '--repo_root=../../edx-platform', 'upgrade-branch', [],
+        pull_request_creator = PullRequestCreator('--repo_root=../../edx-platform', 'upgrade-branch', [],
                                                   [], 'Upgrade python requirements', 'Update python requirements',
-                                                  'make upgrade PR', '--org=edx')
+                                                  'make upgrade PR')
         pull_request_creator.create(True)
 
         assert branch_exists_mock.called
@@ -78,9 +82,10 @@ class BokchoyPullRequestTestCase(TestCase):
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.close_existing_pull_requests',
            return_value=[])
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_github_instance', return_value=None)
-    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.connect_to_repo', return_value=None)
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.repo_from_remote', return_value=None)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_modified_files_list',
            return_value=["requirements/edx/base.txt", "requirements/edx/coverage.txt"])
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_current_commit', return_value='1234567')
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.branch_exists', return_value=True)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.update_list_of_files', return_value=None)
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.create_pull_request', return_value=None)
@@ -89,14 +94,15 @@ class BokchoyPullRequestTestCase(TestCase):
            return_value=Mock(name="fake name", login="fake login"))
     @patch('jenkins.github_helpers.GitHubHelper.delete_branch', return_value=None)
     def test_branch_exists(self, delete_branch_mock, get_user_mock, create_branch_mock, create_pr_mock,
-                           update_files_mock, branch_exists_mock, modified_list_mock, repo_mock, authenticate_mock,
+                           update_files_mock, branch_exists_mock, current_commit_mock,
+                           modified_list_mock, repo_mock, authenticate_mock,
                            close_existing_prs_mock):
         """
         Ensure a merge with no changes to db files will not result in any updates.
         """
-        pull_request_creator = PullRequestCreator('--sha=123', '--repo_root=../../edx-platform', 'upgrade-branch', [],
+        pull_request_creator = PullRequestCreator('--repo_root=../../edx-platform', 'upgrade-branch', [],
                                                   [], 'Upgrade python requirements', 'Update python requirements',
-                                                  'make upgrade PR', '--org=edx')
+                                                  'make upgrade PR')
         pull_request_creator.create(True)
 
         assert branch_exists_mock.called

--- a/jenkins/upgrade_python_requirements.py
+++ b/jenkins/upgrade_python_requirements.py
@@ -10,8 +10,7 @@ from jenkins.pull_request_creator import PullRequestCreator
 @click.command()
 @click.option(
     '--sha',
-    help="Sha of the merge commit to base the new PR off of",
-    required=True,
+    help="DEPRECATED: Ignored, current SHA is read from repo now",
 )
 @click.option(
     '--repo_root',
@@ -21,8 +20,7 @@ from jenkins.pull_request_creator import PullRequestCreator
 )
 @click.option(
     '--org',
-    help="The github organization for the repository to run make upgrade on.",
-    required=True,
+    help="DEPRECATED: Ignored, org is read from repo's remotes now"
 )
 @click.option(
     '--user_reviewers',
@@ -44,10 +42,10 @@ def main(sha, repo_root, org, user_reviewers, team_reviewers):
               "https://openedx.atlassian.net/wiki/spaces/TE/pages/1001521320/Python+Package+Changelogs" \
               ") for the upgraded packages."
 
-    pull_request_creator = PullRequestCreator(sha=sha, repo_root=repo_root, branch_name="upgrade-python-requirements",
+    pull_request_creator = PullRequestCreator(repo_root=repo_root, branch_name="upgrade-python-requirements",
                                               user_reviewers=user_reviewers, team_reviewers=team_reviewers,
                                               commit_message="Updating Python Requirements",
-                                              pr_title="Python Requirements Update", pr_body=pr_body, org=org)
+                                              pr_title="Python Requirements Update", pr_body=pr_body)
 
     pull_request_creator.create(delete_old_pull_requests=True)
 


### PR DESCRIPTION
This is in service of ARCHBOM-1544 (automated code owner config PRs)
and needs to be merged before https://github.com/edx/jenkins-job-dsl-internal/pull/466

Breaking changes to PullRequestCreator:

- No longer accept a base SHA; this is now read from local repo
- Determine Github org and repo name from local repo's remotes:
    - No longer accept org
    - Don't assume folder name matches the github repo name
    - Prevent possible behavior of matching repo in wrong org with
      same name

Reliant scripts still accept sha and org options, but ignore them.
These can be cleaned up after the corresponding jenkins-job-dsl jobs and
scripts no longer pass these options.

Changes to GithubHelper:

- Add get_current_commit to get current SHA of local repo
- Add repo_from_remote to find repo on Github based on local repo
- Add warning comments to initialization, which doesn't do checks that it
  thinks it does