### PR TITLE
Bugfix: Don't fail PR tagging check when additional reviewers present

### DIFF
--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -217,12 +217,12 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
         tagged_for_review = pull_request.get_review_requests()
 
         tagged_users = [user.login for user in tagged_for_review[0]]
-        if not (requested_users is GithubObject.NotSet or set(tagged_users) >= set(requested_users)):
+        if not (requested_users is GithubObject.NotSet or set(requested_users) <= set(tagged_users)):
             logger.info("User taggging failure: Requested %s, actually tagged %s", requested_users, tagged_users)
             raise Exception('Some of the requested reviewers were not tagged on PR for review')
 
         tagged_teams = [team.name for team in tagged_for_review[1]]
-        if not (requested_teams is GithubObject.NotSet or set(tagged_teams) >= set(requested_teams)):
+        if not (requested_teams is GithubObject.NotSet or set(requested_teams) <= set(tagged_teams)):
             logger.info("Team taggging failure: Requested %s, actually tagged %s", requested_teams, tagged_teams)
             raise Exception('Some of the requested teams were not tagged on PR for review')
 

--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -216,13 +216,13 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
             return
         tagged_for_review = pull_request.get_review_requests()
 
-        tagged_users = {user.login for user in tagged_for_review[0]}
-        if not (requested_users is GithubObject.NotSet or tagged_users >= set(requested_users)):
+        tagged_users = [user.login for user in tagged_for_review[0]]
+        if not (requested_users is GithubObject.NotSet or set(tagged_users) >= set(requested_users)):
             logger.info("User taggging failure: Requested %s, actually tagged %s", requested_users, tagged_users)
             raise Exception('Some of the requested reviewers were not tagged on PR for review')
 
-        tagged_teams = {team.name for team in tagged_for_review[1]}
-        if not (requested_teams is GithubObject.NotSet or tagged_teams >= set(requested_teams)):
+        tagged_teams = [team.name for team in tagged_for_review[1]]
+        if not (requested_teams is GithubObject.NotSet or set(tagged_teams) >= set(requested_teams)):
             logger.info("Team taggging failure: Requested %s, actually tagged %s", requested_teams, tagged_teams)
             raise Exception('Some of the requested teams were not tagged on PR for review')
 


### PR DESCRIPTION
GitHub may tag additional, unasked-for reviewers on a PR if a CODEOWNERS
file is present. This change uses set comparison instead of list comparison
so that these extra reviewers can be ignored.

Also document some of the failure modes we've encountered.