### PR TITLE
fix: Don't allow PR creation of one type to close PRs of another

### DIFF
--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -146,10 +146,14 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
     def is_cleanup_pr(self, branch_name):
         return re.fullmatch("jenkins/cleanup-python-code-[a-zA-Z0-9]*", branch_name) is not None
 
-    def close_existing_pull_requests(self, repository, user_login, user_name, target_branch='master'):
+    def close_existing_pull_requests(self, repository, user_login, user_name, target_branch='master',
+                                     branch_name_filter=None):
         """
         Close any existing PR's by the bot user in this PR. This will help
         reduce clutter, since any old PR's will be obsolete.
+        If function branch_name_filter is specified, it will be called with
+        branch names of PRs. The PR will only be closed when the function
+        returns true.
         """
         pulls = repository.get_pulls(state="open")
         deleted_pull_numbers = []
@@ -157,6 +161,8 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
             user = pr.user
             if user.login == user_login and user.name == user_name and pr.base.ref == target_branch:
                 branch_name = pr.head.ref
+                if branch_name_filter and not branch_name_filter(branch_name):
+                    continue
                 logger.info("Deleting PR: #{}".format(pr.number))
                 pr.create_issue_comment("Closing obsolete PR.")
                 pr.edit(state="closed")

--- a/jenkins/pull_request_creator.py
+++ b/jenkins/pull_request_creator.py
@@ -3,6 +3,7 @@ Class helps create GitHub Pull requests
 """
 # pylint: disable=missing-class-docstring,missing-function-docstring,attribute-defined-outside-init
 import logging
+import re
 
 import click
 from github import GithubObject
@@ -98,8 +99,13 @@ class PullRequestCreator:
 
     def delete_old_pull_requests(self):
         LOGGER.info("Checking if there's any old pull requests to delete")
-        deleted_pulls = self.github_helper.close_existing_pull_requests(self.repository, self.user.login,
-                                                                        self.user.name, self.target_branch)
+        # Only delete old PRs with the same base name
+        filter_pattern = "jenkins/{}-[a-zA-Z0-9]*".format(re.escape(self.branch_name))
+        deleted_pulls = self.github_helper.close_existing_pull_requests(
+            self.repository, self.user.login,
+            self.user.name, self.target_branch,
+            branch_name_filter=lambda name: re.fullmatch(filter_pattern, name)
+        )
 
         for num, deleted_pull_number in enumerate(deleted_pulls):
             if num == 0:


### PR DESCRIPTION
Requirements-upgrade PRs were closing cleanup PRs; the former is run with
delete-old enabled, and the latter was not, but this missing check was
bypassing that control.