### PR TITLE
fix: pygithub now requires pyjwt<2.0

### DIFF
--- a/jenkins/codecov_response_metrics.py
+++ b/jenkins/codecov_response_metrics.py
@@ -69,7 +69,7 @@ def is_head_recent(pull_request, time_frame=3600):
         logger.info('{} has no commits. Skipping'.format(pull_request.title))
         return False
     statuses = head_commit.get_combined_status().statuses
-    return any(
+    return any(  # pylint: disable=use-a-generator
         [is_recent(dt, time_frame) for dt in [s.updated_at for s in statuses]]
     )
 

--- a/requirements/aws.txt
+++ b/requirements/aws.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-boto3==1.17.7
+boto3==1.17.41
     # via -r requirements/aws.in
-botocore==1.20.7
+botocore==1.20.41
     # via
     #   boto3
     #   s3transfer
@@ -16,7 +16,7 @@ jmespath==0.10.0
     #   botocore
 python-dateutil==2.8.1
     # via botocore
-s3transfer==0.3.4
+s3transfer==0.3.6
     # via boto3
 six==1.15.0
     # via python-dateutil

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,9 +4,9 @@
 #
 #    make upgrade
 #
-boto3==1.17.7
+boto3==1.17.41
     # via -r requirements/aws.txt
-botocore==1.20.7
+botocore==1.20.41
     # via
     #   -r requirements/aws.txt
     #   boto3
@@ -17,11 +17,11 @@ chardet==3.0.4
     # via requests
 click==7.1.2
     # via -r requirements/base.in
-deprecated==1.2.11
+deprecated==1.2.12
     # via pygithub
-gitdb==4.0.5
+gitdb==4.0.7
     # via gitpython
-gitpython==3.1.13
+gitpython==3.1.14
     # via -r requirements/base.in
 idna==2.10
     # via requests
@@ -30,12 +30,14 @@ jmespath==0.10.0
     #   -r requirements/aws.txt
     #   boto3
     #   botocore
-pygithub==1.54
+pygithub==1.54.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-pyjwt==2.0.1
-    # via pygithub
+pyjwt==1.7.1
+    # via
+    #   -c requirements/constraints.txt
+    #   pygithub
 python-dateutil==2.8.1
     # via
     #   -r requirements/aws.txt
@@ -44,7 +46,7 @@ requests==2.24.0
     # via
     #   -r requirements/base.in
     #   pygithub
-s3transfer==0.3.4
+s3transfer==0.3.6
     # via
     #   -r requirements/aws.txt
     #   boto3
@@ -52,7 +54,7 @@ six==1.15.0
     # via
     #   -r requirements/aws.txt
     #   python-dateutil
-smmap==3.0.5
+smmap==4.0.0
     # via gitdb
 urllib3==1.25.11
     # via

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -30,10 +30,10 @@ tox-battery==0.6.1
     # via -r requirements/ci.in
 tox-travis==0.12
     # via -r requirements/ci.in
-tox==3.21.4
+tox==3.23.0
     # via
     #   -r requirements/ci.in
     #   tox-battery
     #   tox-travis
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via tox

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,3 +19,6 @@ PyGithub<1.54.1
 
 # PyGithub<1.54.1 needs urllib3<1.26
 urllib3<1.26
+
+# pygithub needs version < 2.0
+pyjwt<2.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ appdirs==1.4.4
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-astroid==2.4.2
+astroid==2.5.2
     # via
     #   -r requirements/testing.txt
     #   pylint
@@ -17,9 +17,9 @@ attrs==20.3.0
     # via
     #   -r requirements/testing.txt
     #   pytest
-boto3==1.17.7
+boto3==1.17.41
     # via -r requirements/testing.txt
-botocore==1.20.7
+botocore==1.20.41
     # via
     #   -r requirements/testing.txt
     #   boto3
@@ -44,17 +44,17 @@ click==7.1.2
     #   code-annotations
     #   edx-lint
     #   pip-tools
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via
     #   -r requirements/testing.txt
     #   edx-lint
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/testing.txt
     #   pytest-cov
-ddt==1.4.1
+ddt==1.4.2
     # via -r requirements/testing.txt
-deprecated==1.2.11
+deprecated==1.2.12
     # via
     #   -r requirements/testing.txt
     #   pygithub
@@ -62,24 +62,24 @@ distlib==0.3.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==2.2.18
+django==2.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/testing.txt
     #   code-annotations
     #   edx-lint
-edx-lint==4.0.1
+edx-lint==5.0.0
     # via -r requirements/testing.txt
 filelock==3.0.12
     # via
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-gitdb==4.0.5
+gitdb==4.0.7
     # via
     #   -r requirements/testing.txt
     #   gitpython
-gitpython==3.1.13
+gitpython==3.1.14
     # via -r requirements/testing.txt
 httpretty==1.0.5
     # via -r requirements/testing.txt
@@ -91,7 +91,7 @@ iniconfig==1.1.1
     # via
     #   -r requirements/testing.txt
     #   pytest
-isort==5.7.0
+isort==5.8.0
     # via
     #   -r requirements/testing.txt
     #   pylint
@@ -104,7 +104,7 @@ jmespath==0.10.0
     #   -r requirements/testing.txt
     #   boto3
     #   botocore
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.6.0
     # via
     #   -r requirements/testing.txt
     #   astroid
@@ -128,7 +128,11 @@ pbr==5.5.1
     # via
     #   -r requirements/testing.txt
     #   stevedore
-pip-tools==5.5.0
+pep517==0.10.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.txt
 pluggy==0.13.1
     # via
@@ -142,14 +146,15 @@ py==1.10.0
     #   -r requirements/testing.txt
     #   pytest
     #   tox
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via -r requirements/testing.txt
-pygithub==1.54
+pygithub==1.54.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/testing.txt
-pyjwt==2.0.1
+pyjwt==1.7.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/testing.txt
     #   pygithub
 pylint-celery==0.3
@@ -165,7 +170,7 @@ pylint-plugin-utils==0.6
     #   -r requirements/testing.txt
     #   pylint-celery
     #   pylint-django
-pylint==2.6.0
+pylint==2.7.4
     # via
     #   -r requirements/testing.txt
     #   edx-lint
@@ -203,7 +208,7 @@ requests==2.24.0
     # via
     #   -r requirements/testing.txt
     #   pygithub
-s3transfer==0.3.4
+s3transfer==0.3.6
     # via
     #   -r requirements/testing.txt
     #   boto3
@@ -211,12 +216,11 @@ six==1.15.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/testing.txt
-    #   astroid
     #   edx-lint
     #   python-dateutil
     #   tox
     #   virtualenv
-smmap==3.0.5
+smmap==4.0.0
     # via
     #   -r requirements/testing.txt
     #   gitdb
@@ -237,7 +241,9 @@ text-unidecode==1.3
 toml==0.10.2
     # via
     #   -r requirements/ci.txt
+    #   -r requirements/pip-tools.txt
     #   -r requirements/testing.txt
+    #   pep517
     #   pylint
     #   pytest
     #   tox
@@ -245,7 +251,7 @@ tox-battery==0.6.1
     # via -r requirements/ci.txt
 tox-travis==0.12
     # via -r requirements/ci.txt
-tox==3.21.4
+tox==3.23.0
     # via
     #   -r requirements/ci.txt
     #   tox-battery
@@ -256,7 +262,7 @@ urllib3==1.25.11
     #   -r requirements/testing.txt
     #   botocore
     #   requests
-virtualenv==20.4.2
+virtualenv==20.4.3
     # via
     #   -r requirements/ci.txt
     #   tox

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -6,8 +6,12 @@
 #
 click==7.1.2
     # via pip-tools
-pip-tools==5.5.0
+pep517==0.10.0
+    # via pip-tools
+pip-tools==6.0.1
     # via -r requirements/pip-tools.in
+toml==0.10.2
+    # via pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,15 +4,15 @@
 #
 #    make upgrade
 #
-astroid==2.4.2
+astroid==2.5.2
     # via
     #   pylint
     #   pylint-celery
 attrs==20.3.0
     # via pytest
-boto3==1.17.7
+boto3==1.17.41
     # via -r requirements/base.txt
-botocore==1.20.7
+botocore==1.20.41
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -33,30 +33,30 @@ click==7.1.2
     #   click-log
     #   code-annotations
     #   edx-lint
-code-annotations==1.1.0
+code-annotations==1.1.1
     # via edx-lint
-coverage==5.4
+coverage==5.5
     # via
     #   -r requirements/testing.in
     #   pytest-cov
-ddt==1.4.1
+ddt==1.4.2
     # via -r requirements/testing.in
-deprecated==1.2.11
+deprecated==1.2.12
     # via
     #   -r requirements/base.txt
     #   pygithub
-django==2.2.18
+django==2.2.19
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   code-annotations
     #   edx-lint
-edx-lint==4.0.1
+edx-lint==5.0.0
     # via -r requirements/testing.in
-gitdb==4.0.5
+gitdb==4.0.7
     # via
     #   -r requirements/base.txt
     #   gitpython
-gitpython==3.1.13
+gitpython==3.1.14
     # via -r requirements/base.txt
 httpretty==1.0.5
     # via -r requirements/testing.in
@@ -66,7 +66,7 @@ idna==2.10
     #   requests
 iniconfig==1.1.1
     # via pytest
-isort==5.7.0
+isort==5.8.0
     # via pylint
 jinja2==2.11.3
     # via code-annotations
@@ -75,7 +75,7 @@ jmespath==0.10.0
     #   -r requirements/base.txt
     #   boto3
     #   botocore
-lazy-object-proxy==1.4.3
+lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
     # via jinja2
@@ -91,14 +91,15 @@ pluggy==0.13.1
     # via pytest
 py==1.10.0
     # via pytest
-pycodestyle==2.6.0
+pycodestyle==2.7.0
     # via -r requirements/testing.in
 pygithub==1.54
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-pyjwt==2.0.1
+pyjwt==1.7.1
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   pygithub
 pylint-celery==0.3
@@ -109,7 +110,7 @@ pylint-plugin-utils==0.6
     # via
     #   pylint-celery
     #   pylint-django
-pylint==2.6.0
+pylint==2.7.4
     # via
     #   edx-lint
     #   pylint-celery
@@ -137,17 +138,16 @@ requests==2.24.0
     # via
     #   -r requirements/base.txt
     #   pygithub
-s3transfer==0.3.4
+s3transfer==0.3.6
     # via
     #   -r requirements/base.txt
     #   boto3
 six==1.15.0
     # via
     #   -r requirements/base.txt
-    #   astroid
     #   edx-lint
     #   python-dateutil
-smmap==3.0.5
+smmap==4.0.0
     # via
     #   -r requirements/base.txt
     #   gitdb


### PR DESCRIPTION
A lot of automated CI jobs started failing today because of requirements conflict.
See 
https://build.testeng.edx.org/job/django-lang-pref-middleware-upgrade-python-requirements/49/ 
https://build.testeng.edx.org/job/edx-platform-test-notifier/189369/console
Turns out `pygithub` now requires `pyjwt<2.0` [Reference](https://github.com/PyGithub/PyGithub/releases/tag/v1.54.0)