### PR TITLE
fix: wait a moment before asking about the pull request

### DIFF
--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -5,6 +5,7 @@ import io  # pylint: disable=unused-import
 import logging
 import os
 import re
+import time
 
 from git import Git, Repo
 from github import Github, GithubObject, InputGitAuthor, InputGitTreeElement
@@ -193,6 +194,9 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
                     team_reviewers=team_reviewers,
                 )
                 if verify_reviewers:
+                    # Sometimes GitHub can't find the pull request we just made.
+                    # Try waiting a moment before asking about it.
+                    time.sleep(5)
                     self.verify_reviewers_tagged(pull_request, user_reviewers, team_reviewers)
 
         except Exception as e:


### PR DESCRIPTION
Sometimes the upgrade_requirements job fails with a 404 trying to
retrieve the list of requested reviewers.  Put in a pause to try to
avoid that problem.

An example of a failing build:
https://github.com/edx/openedxstats/runs/3605917319

```
INFO:root:Tagging reviewers: users=NotSet and teams=['community-engineering']
Traceback (most recent call last):
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/github_helpers.py", line 196, in create_pull_request
    self.verify_reviewers_tagged(pull_request, user_reviewers, team_reviewers)
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/github_helpers.py", line 219, in verify_reviewers_tagged
    tagged_users = [user.login for user in tagged_for_review[0]]
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/github_helpers.py", line 219, in <listcomp>
    tagged_users = [user.login for user in tagged_for_review[0]]
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/github/PaginatedList.py", line 59, in __iter__
    newElements = self._grow()
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/github/PaginatedList.py", line 71, in _grow
    newElements = self._fetchNextPage()
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/github/PaginatedList.py", line 203, in _fetchNextPage
    headers, data = self.__requester.requestJsonAndCheck(
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/github/Requester.py", line 317, in requestJsonAndCheck
    return self.__check(
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/github/Requester.py", line 342, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.UnknownObjectException: 404 {"message": "Not Found", "documentation_url": "https://docs.github.com/rest/reference/pulls#list-requested-reviewers-for-a-pull-request"}

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/pull_request_creator.py", line 202, in <module>
    main(auto_envvar_prefix="PR_CREATOR")  # pylint: disable=no-value-for-parameter, unexpected-keyword-arg
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/hostedtoolcache/Python/3.8.11/x64/lib/python3.8/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/pull_request_creator.py", line 198, in main
    creator.create(delete_old_pull_requests)
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/pull_request_creator.py", line 134, in create
    self._create_new_pull_request()
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/pull_request_creator.py", line 87, in _create_new_pull_request
    pr = self.github_helper.create_pull_request(
  File "/home/runner/work/openedxstats/openedxstats/testeng-ci/jenkins/github_helpers.py", line 199, in create_pull_request
    raise Exception(
Exception: Some reviewers could not be tagged on new PR https://github.com/edx/openedxstats/pull/117
```