### PR TITLE
feat: wrap PR link in github action output syntax

### DIFF
--- a/jenkins/tests/test_upgrade_python_requirements.py
+++ b/jenkins/tests/test_upgrade_python_requirements.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, patch
 from jenkins.pull_request_creator import PullRequestCreator
 
 
-class BokchoyPullRequestTestCase(TestCase):
+class UpgradePythonRequirementsPullRequestTestCase(TestCase):
     """
     Test Case class for PR creator.
     """
@@ -77,6 +77,43 @@ class BokchoyPullRequestTestCase(TestCase):
         self.assertEqual(update_files_mock.call_count, 1)
         assert create_pr_mock.called
         assert not delete_branch_mock.called
+
+    @patch('jenkins.pull_request_creator.PullRequestCreator._get_user',
+           return_value=Mock(name="fake name", login="fake login"))
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_github_instance',
+           return_value=Mock())
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.repo_from_remote', return_value=Mock())
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_modified_files_list',
+           return_value=["requirements/edx/base.txt", "requirements/edx/coverage.txt"])
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.get_current_commit', return_value='1234567')
+    # all above this unused params, no need to interact with those mocks
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.branch_exists', return_value=False)
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.update_list_of_files', return_value=None)
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.create_pull_request')
+    @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.create_branch', return_value=None)
+    @patch('builtins.print')
+    def test_outputs_url_on_success(self, print_mock, create_branch_mock, create_pr_mock,
+                                    update_files_mock, branch_exists_mock, *args):
+        """
+        Ensure that a successful run outputs the URL consumable by github actions
+        """
+        pull_request_creator = PullRequestCreator('--repo_root=../../edx-platform', 'upgrade-branch', [],
+                                                  [], 'Upgrade python requirements', 'Update python requirements',
+                                                  'make upgrade PR', output_pr_url_for_github_action=True)
+        pull_request_creator.create(False)
+
+        assert branch_exists_mock.called
+        assert create_branch_mock.called
+        self.assertEqual(create_branch_mock.call_count, 1)
+        assert update_files_mock.called
+        self.assertEqual(update_files_mock.call_count, 1)
+        assert create_pr_mock.called
+        assert print_mock.called_once
+        found_matching_call = False
+        for call in print_mock.call_args_list:
+            if 'set-output' in call.args[0]:
+                found_matching_call = True
+        assert found_matching_call
 
     @patch('jenkins.pull_request_creator.PullRequestCreator.github_helper.close_existing_pull_requests',
            return_value=[])


### PR DESCRIPTION
Adds an option `--output-pr-url-for-github-action` to the `pull_request_creator` script which causes the resulting PR URL to be put in a github-parseable output tag, for use downstream in a github action workflow.

To use the new output param, set an `id` on the step from which the `pull_request_creator` is invoked, like https://github.com/edx/edx-proctoring/blob/5d025d4c78142e0da518ca49a761837e8d080831/.github/workflows/upgrade-python-requirements.yml#L47. Then in subsequent steps of the same workflow you can get the output PR using the expression `${{ steps.<whatever id you chose>.outputs.generated_pr }}`. Note that the param will only be set if a new PR is created; if no changes are needed or a branch with the needed changes already exists, then the script will succeed but not output the URL of any PR.

JIRA:EDUCATOR-5262