### PR TITLE
fix: Use standard git exclusions in PR creation

### DIFF
--- a/jenkins/github_helpers.py
+++ b/jenkins/github_helpers.py
@@ -127,7 +127,7 @@ class GitHubHelper:  # pylint: disable=missing-class-docstring
 
         if untracked_files_required:
             modified_files = git_instance.ls_files("--modified")
-            untracked_files = git_instance.ls_files("--others", "--exclude-from=.gitignore")
+            untracked_files = git_instance.ls_files("--others", "--exclude-standard")
             updated_files = modified_files + '\n' + untracked_files \
                 if (len(modified_files) > 0 and len(untracked_files) > 0) \
                 else modified_files + untracked_files


### PR DESCRIPTION
Switching to '--exclude-standard' option to use standard git exclusions for untracked files while creating PRs. 
For reference see [docs](https://git-scm.com/docs/git-ls-files)

Previously we were using `--exclude-from=.gitignore` which ignores only the files added in .gitignore but sometimes we want to ignore some file without updating .gitignore. Standard approach for this is to update '.git/info/exclude' file locally but that doesn't work with the `--exclude-from` thing. Using `--exclude-standard`, we can achieve the standard behaviour.