### PR TITLE
Fix delete branch functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ cover_html/
 ### Local development artifacts
 requirements/private.in
 requirements/private.txt
+venv/

--- a/jenkins/pull_request_creator.py
+++ b/jenkins/pull_request_creator.py
@@ -124,6 +124,10 @@ class PullRequestCreator:
             self.pr_body += "\nhttps://github.com/{}/pull/{}".format(self.repository.full_name,
                                                                      deleted_pull_number)
 
+    def _delete_old_branch(self):
+        LOGGER.info("Deleting existing old branch with same name")
+        self.github_helper.delete_branch(self.repository, self.branch)
+
     def create(self, delete_old_pull_requests, untracked_files_required=False):
         self._set_github_data(untracked_files_required)
 
@@ -131,17 +135,16 @@ class PullRequestCreator:
             LOGGER.info("No changes needed")
             return
 
-        if self.force_delete_old_prs:
+        if self.force_delete_old_prs or delete_old_pull_requests:
             self.delete_old_pull_requests()
+            if self._branch_exists():
+                self._delete_old_branch()
 
         elif self._branch_exists():
             LOGGER.info("Branch for this sha already exists")
             return
 
         self._create_new_branch()
-
-        if delete_old_pull_requests:
-            self.delete_old_pull_requests()
 
         self._create_new_pull_request()
 


### PR DESCRIPTION
## Desc
This PR fixes the delete branch functionality for existing branches. If a branch exists already but it isn't linked to any open PR then the script doesn't cater deleting that branch.
Team noted this bug during the schedules upgrade Requirement Job failures where the job was failing if a branch with same `SHA` existed. Notably we are appending the commit SHA of the last commit on master branch and if the commit is same between different job runs we run into this issue where the job fails. 
The `existing branch check` was bypassed due to the `force delete flag` which has been fixed in this PR:https://github.com/edx/testeng-ci/pull/322
Previously, for repos where there is seldom a new commit, the job would keep passing without making any upgrade PR and just log `Branch for this SHA` already exists.
With this change the job will close all existing branches of requirements upgrade irrespective of a whether it has an open PR or not.

**Testing:**
Tested on my personal fork: https://github.com/aht007/edx-rest-api-client/actions/runs/3486762777/jobs/5833608471