### PR TITLE
Set force delete param to False by default

### DIFF
--- a/jenkins/pull_request_creator.py
+++ b/jenkins/pull_request_creator.py
@@ -186,7 +186,7 @@ class PullRequestCreator:
 )
 @click.option(
     '--force-delete-old-prs/--no-force-delete-old-prs',
-    default=True,
+    default=False,
     help="If set, force delete old branches with the same base branch name and close their PRs"
 )
 @click.option(


### PR DESCRIPTION
The flag was added for `Bulk repo update`. It had been set to True by default but that is messing up with the requirements upgrade job. `Bulk repo update` job's interface provides us the option to set the flag to true or false depending upon our usage and hence this should be False by default so that it doesn't cause issue with other jobs. 