### PR TITLE
chore: mention `packaging` as explicit dependency

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,5 +4,6 @@
 
 GitPython
 PyGithub
+packaging             # used in create pull request script to compare package versions
 requests
 click

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,6 +30,8 @@ jmespath==1.0.0
     #   -r requirements/aws.txt
     #   boto3
     #   botocore
+packaging==21.3
+    # via -r requirements/base.in
 pygithub==1.54.0.1
     # via
     #   -c requirements/constraints.txt
@@ -38,6 +40,8 @@ pyjwt==1.7.1
     # via
     #   -c requirements/constraints.txt
     #   pygithub
+pyparsing==3.0.9
+    # via packaging
 python-dateutil==2.8.2
     # via
     #   -r requirements/aws.txt

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -81,7 +81,9 @@ mccabe==0.7.0
 mock==4.0.3
     # via -r requirements/testing.in
 packaging==21.3
-    # via pytest
+    # via
+    #   -r requirements/base.txt
+    #   pytest
 pbr==5.9.0
     # via stevedore
 platformdirs==2.5.2
@@ -118,7 +120,9 @@ pylint-plugin-utils==0.7
     #   pylint-celery
     #   pylint-django
 pyparsing==3.0.9
-    # via packaging
+    # via
+    #   -r requirements/base.txt
+    #   packaging
 pytest==7.1.2
     # via
     #   -r requirements/testing.in


### PR DESCRIPTION
With the recent change pull request creator script, we are now comparing the version of packages during the upgrade python requirements script. We are using this package but not mentioned in the base.in due to which this script was failing for the Bulk Repo Update job.